### PR TITLE
Fix Windows build with M_PI

### DIFF
--- a/src/ecs/components/Script.cc
+++ b/src/ecs/components/Script.cc
@@ -6,6 +6,9 @@
 #include <glm/glm.hpp>
 #include <picojson/picojson.h>
 
+#define _USE_MATH_DEFINES
+#include <math.h>
+
 namespace ecs {
     template<>
     bool Component<Script>::LoadEntity(Lock<AddRemove> lock, Tecs::Entity &dst, const picojson::value &src) {


### PR DESCRIPTION
Windows does not currently compile on master due to missing M_PI defines in Visual Studio (sigh).

This small PR fixes the Windows build.