### PR TITLE
Preserve the player entity across level loads, and clean up entity ownership

### DIFF
--- a/src/ecs/Ecs.cc
+++ b/src/ecs/Ecs.cc
@@ -5,6 +5,17 @@
 #include <typeindex>
 
 namespace ecs {
+    std::string ToString(Lock<Read<Name>> lock, Tecs::Entity e) {
+        if (lock.Exists(e)) {
+            if (e.Has<Name>(lock)) {
+                return e.Get<Name>(lock) + "(" + std::to_string(e.id) + ")";
+            } else {
+                return "Entity(" + std::to_string(e.id) + ")";
+            }
+        } else {
+            return "Entity(NULL)";
+        }
+    }
     void Entity::Destroy() {
         auto lock = em->tecs.StartTransaction<Tecs::AddRemove>();
         e.Destroy(lock);

--- a/src/ecs/Ecs.hh
+++ b/src/ecs/Ecs.hh
@@ -75,6 +75,8 @@ namespace ecs {
     template<typename T>
     using Removed = Tecs::Removed<T>;
 
+    std::string ToString(Lock<Read<Name>> lock, Tecs::Entity e);
+
     class EntityManager;
 
     template<typename T>

--- a/src/ecs/components/Animation.cc
+++ b/src/ecs/components/Animation.cc
@@ -39,15 +39,15 @@ namespace ecs {
         return true;
     }
 
-    void Animation::AnimateToState(uint32 i) {
-        if (i > states.size()) {
+    void Animation::AnimateToState(size_t state) {
+        if (state >= states.size()) {
             std::stringstream ss;
-            ss << "\"" << i << "\" is an invalid state for this Animation with " << states.size() << " states";
+            ss << "\"" << state << "\" is an invalid state for this Animation with " << states.size() << " states";
             throw std::runtime_error(ss.str());
         }
-        if (i == curState) return;
+        if (state == curState) return;
 
         prevState = curState;
-        curState = i;
+        curState = state;
     }
 } // namespace ecs

--- a/src/ecs/components/Animation.hh
+++ b/src/ecs/components/Animation.hh
@@ -9,7 +9,7 @@
 namespace ecs {
     class Animation {
     public:
-        void AnimateToState(uint32 i);
+        void AnimateToState(size_t state);
 
         struct State {
             glm::vec3 pos;
@@ -23,8 +23,8 @@ namespace ecs {
         };
 
         vector<State> states;
-        int curState = -1;
-        int prevState = -1;
+        size_t curState = 0;
+        size_t prevState = 0;
 
         /**
          * the time it takes to animate to the given state

--- a/src/ecs/components/Owner.hh
+++ b/src/ecs/components/Owner.hh
@@ -3,14 +3,16 @@
 #include <ecs/Components.hh>
 
 namespace ecs {
-    enum class OwnerType { INVALID = 0, GAME_LOGIC, XR_MANAGER };
-
     struct Owner {
+        enum SystemId { INVALID = 0, GAME_LOGIC, XR_MANAGER };
+        enum class OwnerType { INVALID = 0, SYSTEM, PLAYER };
+
         Owner() : id(0), type(OwnerType::INVALID) {}
-        Owner(OwnerType type) : id(0), type(type) {}
+        Owner(SystemId id) : id(id), type(OwnerType::SYSTEM) {}
+        Owner(OwnerType type, size_t id) : id(id), type(type) {}
 
         inline bool operator==(const Owner &other) const {
-            return type == other.type;
+            return type == other.type && id == other.id;
         }
 
         size_t id;

--- a/src/ecs/systems/AnimationSystem.cc
+++ b/src/ecs/systems/AnimationSystem.cc
@@ -20,9 +20,7 @@ namespace ecs {
             auto &animation = ent.Get<Animation>(lock);
             auto &transform = ent.Get<Transform>(lock);
 
-            if (animation.prevState < 0 || animation.curState < 0 || animation.curState == animation.prevState) {
-                continue;
-            }
+            if (animation.curState == animation.prevState) continue;
 
             sp::Assert(animation.curState < animation.states.size(), "invalid current state");
             sp::Assert(animation.prevState < animation.states.size(), "invalid previous state");

--- a/src/ecs/systems/HumanControlSystem.hh
+++ b/src/ecs/systems/HumanControlSystem.hh
@@ -33,12 +33,18 @@ namespace ecs {
         /**
          * Assigns a default HumanController to the given entity.
          */
-        ecs::Handle<HumanController> AssignController(ecs::Entity entity, sp::PhysxManager &px);
+        HumanController &AssignController(ecs::Lock<ecs::AddRemove> lock, Tecs::Entity entity, sp::PhysxManager &px);
 
         /**
          * Teleports the entity and properly syncs to physx.
          */
-        void Teleport(ecs::Entity entity, glm::vec3 position, glm::quat rotation = glm::quat());
+        void Teleport(ecs::Lock<ecs::Write<ecs::Transform, ecs::HumanController>> lock,
+                      Tecs::Entity entity,
+                      glm::vec3 position);
+        void Teleport(ecs::Lock<ecs::Write<ecs::Transform, ecs::HumanController>> lock,
+                      Tecs::Entity entity,
+                      glm::vec3 position,
+                      glm::quat rotation);
 
     private:
         glm::vec3 CalculatePlayerVelocity(ecs::Entity entity,

--- a/src/game/GameLogic.hh
+++ b/src/game/GameLogic.hh
@@ -21,6 +21,7 @@ namespace sp {
         void HandleInput();
         bool Frame(double dtSinceLastFrame);
 
+        void ResetPlayer();
         void LoadScene(string name);
         void ReloadScene(string arg);
         void PrintDebug();
@@ -28,16 +29,16 @@ namespace sp {
         void SetSignal(string args);
         void ClearSignal(string args);
 
-        ecs::Entity GetPlayer();
-
-    private:
-        ecs::Entity CreateGameLogicEntity();
+        Tecs::Entity GetPlayer() {
+            return player;
+        }
 
     private:
         Game *game;
         InputManager *input = nullptr;
         ecs::HumanControlSystem humanControlSystem;
         shared_ptr<Scene> scene;
+        Tecs::Entity player;
         Tecs::Entity flashlight;
         CFuncCollection funcs;
     };

--- a/src/graphics/GraphicsManager.cc
+++ b/src/graphics/GraphicsManager.cc
@@ -213,16 +213,14 @@ namespace sp {
         return true;
     }
 
-    void GraphicsManager::AddPlayerView(vector<ecs::Entity> entities) {
-        for (auto entity : entities) {
-            AddPlayerView(entity);
-        }
-    }
-
     void GraphicsManager::AddPlayerView(ecs::Entity entity) {
         ecs::ValidateView(entity);
 
         playerViews.push_back(entity);
+    }
+
+    void GraphicsManager::AddPlayerView(Tecs::Entity entity) {
+        playerViews.push_back(ecs::Entity(&game->entityManager, entity));
     }
 
     void GraphicsManager::RenderLoading() {

--- a/src/graphics/GraphicsManager.hh
+++ b/src/graphics/GraphicsManager.hh
@@ -26,8 +26,8 @@ namespace sp {
         void ReloadContext();
         bool HasActiveContext();
 
-        void AddPlayerView(vector<ecs::Entity> entities);
         void AddPlayerView(ecs::Entity entity);
+        void AddPlayerView(Tecs::Entity entity);
 
         void RenderLoading();
 

--- a/src/physx/PhysxManager.cc
+++ b/src/physx/PhysxManager.cc
@@ -1,16 +1,17 @@
-#define _USE_MATH_DEFINES
 #include "physx/PhysxManager.hh"
 
-#include <Common.hh>
+#include "Common.hh"
+#include "assets/AssetManager.hh"
+#include "assets/Model.hh"
+#include "core/CFunc.hh"
+#include "core/CVar.hh"
+#include "core/Game.hh"
+#include "core/Logging.hh"
+#include "ecs/EcsImpl.hh"
+
+#define _USE_MATH_DEFINES
 #include <PxScene.h>
-#include <assets/AssetManager.hh>
-#include <assets/Model.hh>
 #include <chrono>
-#include <core/CFunc.hh>
-#include <core/CVar.hh>
-#include <core/Game.hh>
-#include <core/Logging.hh>
-#include <ecs/EcsImpl.hh>
 #include <fstream>
 #include <physx/PhysxUtils.hh>
 
@@ -218,6 +219,7 @@ namespace sp {
                 if (!ph.actor && ph.model) { ph.actor = CreateActor(ph.model, ph.desc, ent); }
 
                 if (ph.actor && transform.ClearDirty()) {
+                    transform.UpdateCachedTransform(lock);
                     auto position = transform.GetGlobalTransform(lock) * glm::vec4(0, 0, 0, 1);
                     auto rotate = transform.GetGlobalRotation(lock);
 

--- a/src/xr/XrManager.cc
+++ b/src/xr/XrManager.cc
@@ -317,7 +317,7 @@ namespace sp::xr {
                 // Add a transform to the VR origin if one does not already exist
                 if (!vrOrigin.Has<ecs::Transform>()) {
                     vrOrigin.Assign<ecs::Transform>();
-                    auto player = game->logic.GetPlayer();
+                    auto player = ecs::Entity(&game->entityManager, game->logic.GetPlayer());
 
                     if (player.Valid() && player.Has<ecs::Transform>()) {
                         auto lock = game->entityManager.tecs.StartTransaction<ecs::Write<ecs::Transform>>();
@@ -586,7 +586,7 @@ namespace sp::xr {
             Logf("Resetting VR Origin");
             auto lock = game->entityManager.tecs.StartTransaction<ecs::Read<ecs::Name>, ecs::Write<ecs::Transform>>();
             auto vrOrigin = ecs::EntityWith<ecs::Name>(lock, "vr-origin");
-            auto player = game->logic.GetPlayer().GetEntity();
+            auto player = game->logic.GetPlayer();
             if (vrOrigin && vrOrigin.Has<ecs::Transform>(lock) && player && player.Has<ecs::Transform>(lock)) {
                 auto &vrTransform = vrOrigin.Get<ecs::Transform>(lock);
                 auto &playerTransform = player.Get<ecs::Transform>(lock);
@@ -611,7 +611,7 @@ namespace sp::xr {
      */
     inline ecs::Entity XrManager::CreateXrEntity() {
         auto newEntity = game->entityManager.NewEntity();
-        newEntity.Assign<ecs::Owner>(ecs::OwnerType::XR_MANAGER);
+        newEntity.Assign<ecs::Owner>(ecs::Owner::SystemId::XR_MANAGER);
         return newEntity;
     }
 }; // namespace sp::xr


### PR DESCRIPTION
This PR fixes a bunch of issues with how the player entity was handled. The scene is now isolated from system entities like the player, which means null scenes will not crash the game anymore.

- The player spawn is defined in the scene as an entity named "player", with a transform component.
- The console command `reloadscene` will reset the scene without moving the player, and `reloadscene reset` will respawn the player.
- Some bugs in setting the player's rotation on initial level load have been fixed.
- More sections of code converted to Tecs.