### PR TITLE
Fix the URL for the glfw submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -54,7 +54,7 @@
 	url = https://github.com/AnalyticalGraphicsInc/gltf-pipeline.git
 [submodule "ext/glfw"]
 	path = ext/glfw
-	url = git@github.com:frustra/glfw.git
+	url = https://github.com/frustra/glfw.git
 [submodule "ext/Tecs"]
 	path = ext/Tecs
 	url = https://github.com/xthexder/Tecs.git


### PR DESCRIPTION
This small PR fixes the glfw submodule to use an HTTPS Git URL.

This enables a better experience when cloning on Windows: cloning from the SSH URL does not get configured automatically by GitHub when installing on Windows, but HTTPS works out of the box.

Having this submodule use an SSH URL prevents the repo from cloning and setting up submodules on Windows during the initial clone, which leaves the repo in a bad state.