### PR TITLE
Don't malloc when calling Assert, add Abort()

### DIFF
--- a/src/core/assets/AssetManager.cc
+++ b/src/core/assets/AssetManager.cc
@@ -177,7 +177,7 @@ namespace sp {
                         asset->valid.test_and_set();
                         asset->valid.notify_all();
                     } else {
-                        Assert(false, "Asset does not exist: " + path);
+                        Abort("Asset does not exist: " + path);
                     }
                 }));
             }

--- a/src/core/core/Common.cc
+++ b/src/core/core/Common.cc
@@ -15,12 +15,10 @@
 #endif
 
 namespace sp {
-    void Assert(bool condition, const string &message) {
-        if (!condition) {
-            Errorf("assertion failed: %s", message);
-            os_break();
-            throw std::runtime_error(message);
-        }
+    void Abort(const string &message) {
+        Errorf("assertion failed: %s", message);
+        os_break();
+        throw std::runtime_error(message);
     }
 
     void DebugBreak() {

--- a/src/core/core/Common.hh
+++ b/src/core/core/Common.hh
@@ -30,8 +30,11 @@ typedef int32_t int32;
 typedef uint64_t uint64;
 typedef int64_t int64;
 
+#define Assert(condition, message)                                                                                     \
+    if (!(condition)) ::sp::Abort(message);
+
 namespace sp {
-    void Assert(bool condition, const string &message);
+    void Abort(const string &message);
     void DebugBreak();
 
     uint32 CeilToPowerOfTwo(uint32 v);

--- a/src/core/core/Logging.hh
+++ b/src/core/core/Logging.hh
@@ -8,87 +8,80 @@
 #include <memory>
 #include <string>
 
-#define Debugf(...) sp::logging::Debug(__FILE__, __LINE__, __VA_ARGS__)
-#define Logf(...) sp::logging::Log(__FILE__, __LINE__, __VA_ARGS__)
-#define Errorf(...) sp::logging::Error(__FILE__, __LINE__, __VA_ARGS__)
+#define Debugf(...) ::sp::logging::Debug(__FILE__, __LINE__, __VA_ARGS__)
+#define Logf(...) ::sp::logging::Log(__FILE__, __LINE__, __VA_ARGS__)
+#define Errorf(...) ::sp::logging::Error(__FILE__, __LINE__, __VA_ARGS__)
 
-namespace sp {
-    namespace logging {
-        enum class Level { Error, Log, Debug };
+namespace sp::logging {
+    enum class Level { Error, Log, Debug };
 
-        void GlobalLogOutput(Level lvl, const std::string &line);
+    void GlobalLogOutput(Level lvl, const std::string &line);
 
-        inline static const char *basename(const char *file) {
-            const char *r;
-            if ((r = strrchr(file, '/'))) return r + 1;
-            if ((r = strrchr(file, '\\'))) return r + 1;
-            return file;
+    inline static const char *basename(const char *file) {
+        const char *r;
+        if ((r = strrchr(file, '/'))) return r + 1;
+        if ((r = strrchr(file, '\\'))) return r + 1;
+        return file;
+    }
+
+    // Convert all std::strings to const char* using constexpr if (C++17)
+    // Source: https://gist.github.com/Zitrax/a2e0040d301bf4b8ef8101c0b1e3f1d5
+    template<typename T>
+    auto convert(T &&t) {
+        if constexpr (std::is_same<std::remove_cv_t<std::remove_reference_t<T>>, std::string>::value) {
+            return std::forward<T>(t).c_str();
+        } else {
+            return std::forward<T>(t);
         }
+    }
 
-        // Convert all std::strings to const char* using constexpr if (C++17)
-        // Source: https://gist.github.com/Zitrax/a2e0040d301bf4b8ef8101c0b1e3f1d5
-        template<typename T>
-        auto convert(T &&t) {
-            if constexpr (std::is_same<std::remove_cv_t<std::remove_reference_t<T>>, std::string>::value) {
-                return std::forward<T>(t).c_str();
-            } else {
-                return std::forward<T>(t);
-            }
-        }
-
-        template<typename... T>
-        inline static void writeFormatter(Level lvl, const std::string &fmt, T &&...t) {
+    template<typename... T>
+    inline static void writeFormatter(Level lvl, const std::string &fmt, T &&...t) {
 #ifdef SP_PACKAGE_RELEASE
-            if (lvl == logging::Level::Debug) return;
+        if (lvl == logging::Level::Debug) return;
 #endif
-            int size = std::snprintf(nullptr, 0, fmt.c_str(), std::forward<T>(t)...);
-            std::unique_ptr<char[]> buf(new char[size + 1]);
-            std::snprintf(buf.get(), size + 1, fmt.c_str(), std::forward<T>(t)...);
-            std::cerr << buf.get();
+        int size = std::snprintf(nullptr, 0, fmt.c_str(), std::forward<T>(t)...);
+        std::unique_ptr<char[]> buf(new char[size + 1]);
+        std::snprintf(buf.get(), size + 1, fmt.c_str(), std::forward<T>(t)...);
+        std::cerr << buf.get();
 
-            if (lvl != logging::Level::Debug) { GlobalLogOutput(lvl, string(buf.get(), buf.get() + size)); }
-        }
+        if (lvl != logging::Level::Debug) { GlobalLogOutput(lvl, string(buf.get(), buf.get() + size)); }
+    }
 
-        template<typename T1, typename... Tn>
-        inline static void writeLog(Level lvl, const char *file, int line, const std::string &fmt, T1 t1, Tn &&...tn) {
+    template<typename T1, typename... Tn>
+    inline static void writeLog(Level lvl, const char *file, int line, const std::string &fmt, T1 t1, Tn &&...tn) {
 #ifdef SP_VERBOSE_LOGGING
-            writeFormatter(lvl,
-                           fmt + "  (%s:%d)\n",
-                           convert(t1),
-                           convert(std::forward<Tn>(tn))...,
-                           basename(file),
-                           line);
+        writeFormatter(lvl, fmt + "  (%s:%d)\n", convert(t1), convert(std::forward<Tn>(tn))..., basename(file), line);
 #else
-            writeFormatter(lvl, fmt + "\n", convert(t1), convert(std::forward<Tn>(tn))...);
+        writeFormatter(lvl, fmt + "\n", convert(t1), convert(std::forward<Tn>(tn))...);
 #endif
-        }
+    }
 
-        inline static void writeLog(Level lvl, const char *file, int line, const std::string &str) {
+    inline static void writeLog(Level lvl, const char *file, int line, const std::string &str) {
 #ifdef SP_VERBOSE_LOGGING
-            writeFormatter(lvl, "%s  (%s:%d)\n", convert(str), basename(file), line);
+        writeFormatter(lvl, "%s  (%s:%d)\n", convert(str), basename(file), line);
 #else
-            writeFormatter(lvl, "%s\n", convert(str));
+        writeFormatter(lvl, "%s\n", convert(str));
 #endif
-        }
+    }
 
-        template<typename... T>
-        static void ConsoleWrite(Level lvl, const std::string &fmt, T... t) {
-            writeFormatter(lvl, fmt + "\n", convert(std::forward<T>(t))...);
-        }
+    template<typename... T>
+    static void ConsoleWrite(Level lvl, const std::string &fmt, T... t) {
+        writeFormatter(lvl, fmt + "\n", convert(std::forward<T>(t))...);
+    }
 
-        template<typename... T>
-        static void Log(const char *file, int line, const std::string &fmt, T... t) {
-            writeLog(Level::Log, file, line, "[log] " + fmt, t...);
-        }
+    template<typename... T>
+    static void Log(const char *file, int line, const std::string &fmt, T... t) {
+        writeLog(Level::Log, file, line, "[log] " + fmt, t...);
+    }
 
-        template<typename... T>
-        static void Debug(const char *file, int line, const std::string &fmt, T... t) {
-            writeLog(Level::Debug, file, line, "[dbg] " + fmt, t...);
-        }
+    template<typename... T>
+    static void Debug(const char *file, int line, const std::string &fmt, T... t) {
+        writeLog(Level::Debug, file, line, "[dbg] " + fmt, t...);
+    }
 
-        template<typename... T>
-        static void Error(const char *file, int line, const std::string &fmt, T... t) {
-            writeLog(Level::Error, file, line, "[err] " + fmt, t...);
-        }
-    } // namespace logging
-} // namespace sp
+    template<typename... T>
+    static void Error(const char *file, int line, const std::string &fmt, T... t) {
+        writeLog(Level::Error, file, line, "[err] " + fmt, t...);
+    }
+} // namespace sp::logging

--- a/src/core/ecs/components/Events.cc
+++ b/src/core/ecs/components/Events.cc
@@ -27,7 +27,7 @@ namespace ecs {
                 } else if (dest.second.is<picojson::array>()) {
                     targetList = dest.second.get<picojson::array>();
                 } else {
-                    sp::Assert(false, "Invalid event target");
+                    sp::Abort("Invalid event target");
                 }
                 for (auto target : targetList) {
                     auto targetName = target.get<std::string>();

--- a/src/core/ecs/components/Signals.cc
+++ b/src/core/ecs/components/Signals.cc
@@ -35,7 +35,7 @@ namespace ecs {
                 } else if (source.second.is<picojson::array>()) {
                     originList = source.second.get<picojson::array>();
                 } else {
-                    sp::Assert(false, "Invalid signal source");
+                    sp::Abort("Invalid signal source");
                 }
                 for (auto origin : originList) {
                     auto originName = origin.get<std::string>();
@@ -210,7 +210,7 @@ namespace ecs {
                     output = output.value_or(1.0) * val;
                     break;
                 default:
-                    sp::Assert(false, "Bad signal combine operator");
+                    sp::Abort("Bad signal combine operator");
                 }
             }
             return output.value_or(0.0);
@@ -229,13 +229,13 @@ namespace ecs {
                     output = output.value_or(false) || val;
                     break;
                 default:
-                    sp::Assert(false, "Bad signal combine operator");
+                    sp::Abort("Bad signal combine operator");
                 }
             }
             return output.value_or(false) ? 1.0 : 0.0;
         } break;
         default:
-            sp::Assert(false, "Bad signal combine operator");
+            sp::Abort("Bad signal combine operator");
             return 0.0;
         }
     }

--- a/src/core/ecs/components/Transform.cc
+++ b/src/core/ecs/components/Transform.cc
@@ -57,8 +57,7 @@ namespace ecs {
 
     void Transform::UpdateCachedTransform(Lock<Write<Transform>> lock) {
         if (this->parent) {
-            sp::Assert(this->parent.Has<Transform>(lock),
-                       "cannot be relative to something that does not have a Transform");
+            Assert(this->parent.Has<Transform>(lock), "cannot be relative to something that does not have a Transform");
 
             auto &parentTransform = this->parent.Get<Transform>(lock);
 
@@ -76,8 +75,7 @@ namespace ecs {
 
     glm::mat4 Transform::GetGlobalTransform(Lock<Read<Transform>> lock) const {
         if (this->parent) {
-            sp::Assert(this->parent.Has<Transform>(lock),
-                       "cannot be relative to something that does not have a Transform");
+            Assert(this->parent.Has<Transform>(lock), "cannot be relative to something that does not have a Transform");
 
             auto &parentTransform = this->parent.Get<Transform>(lock);
 
@@ -95,9 +93,7 @@ namespace ecs {
         glm::quat model = glm::identity<glm::quat>();
 
         if (this->parent) {
-            sp::Assert(this->parent.Has<Transform>(lock),
-                       "cannot be relative to something that does not have a Transform");
-
+            Assert(this->parent.Has<Transform>(lock), "cannot be relative to something that does not have a Transform");
             model = this->parent.Get<Transform>(lock).GetGlobalRotation(lock);
         }
 

--- a/src/graphics/graphics/opengl/GLModel.cc
+++ b/src/graphics/graphics/opengl/GLModel.cc
@@ -294,7 +294,7 @@ namespace sp {
             return GL_TRIANGLE_FAN;
 
         default:
-            Assert(false, "Unknown Model::DrawMode");
+            Abort("Unknown Model::DrawMode");
             return GL_TRIANGLES;
         }
     }

--- a/src/graphics/graphics/opengl/Graphics.cc
+++ b/src/graphics/graphics/opengl/Graphics.cc
@@ -7,7 +7,7 @@ namespace sp {
         auto err = glGetError();
         if (err) {
             Errorf("OpenGL error %d", err);
-            Assert(false, "OpenGL error at " + message);
+            Abort("OpenGL error at " + message);
         }
     }
 } // namespace sp

--- a/src/graphics/graphics/opengl/PixelFormat.cc
+++ b/src/graphics/graphics/opengl/PixelFormat.cc
@@ -9,7 +9,7 @@ namespace sp {
 
     const GLPixelFormat GLPixelFormat::PixelFormatMapping(PixelFormat in) {
         switch (in) { PF_DEFINITIONS }
-        Assert(false, "invalid PixelFormat");
+        Abort("invalid PixelFormat");
         return GLPixelFormat{};
     };
 

--- a/src/graphics/graphics/opengl/Shader.hh
+++ b/src/graphics/graphics/opengl/Shader.hh
@@ -135,12 +135,12 @@ namespace sp {
 
         template<typename ValueType>
         void Set(Uniform &u, const ValueType &v) {
-            Assert(false, "unimplemented uniform type");
+            Abort("unimplemented uniform type");
         }
 
         template<typename ValueType>
         void Set(Uniform &u, const ValueType v[], GLsizei count) {
-            Assert(false, "unimplemented uniform type");
+            Abort("unimplemented uniform type");
         }
 
     private:

--- a/src/graphics/graphics/vulkan/Common.cc
+++ b/src/graphics/graphics/vulkan/Common.cc
@@ -5,7 +5,7 @@
 namespace sp::vulkan {
     void AssertVKSuccess(vk::Result result, std::string message) {
         if (result == vk::Result::eSuccess) return;
-        Assert(false, message + " (" + vk::to_string(result) + ")");
+        Abort(message + " (" + vk::to_string(result) + ")");
     }
 
     void AssertVKSuccess(VkResult result, std::string message) {

--- a/src/graphics/graphics/vulkan/DeviceContext.cc
+++ b/src/graphics/graphics/vulkan/DeviceContext.cc
@@ -179,7 +179,7 @@ namespace sp::vulkan {
         };
 
         if (!findQueue(QUEUE_TYPE_GRAPHICS, vk::QueueFlagBits::eGraphics | vk::QueueFlagBits::eCompute, {}, 1.0f, true))
-            Assert(false, "could not find a supported graphics queue family");
+            Abort("could not find a supported graphics queue family");
 
         if (!findQueue(QUEUE_TYPE_COMPUTE, vk::QueueFlagBits::eCompute, {}, 0.5f)) {
             // must be only one queue that supports compute, fall back to it
@@ -842,7 +842,7 @@ namespace sp::vulkan {
     shared_ptr<Shader> DeviceContext::CreateShader(const string &name, Hash64 compareHash) {
         auto asset = GAssets.Load("shaders/vulkan/bin/" + name + ".spv");
         if (!asset) {
-            Assert(false, "could not load shader: " + name);
+            Abort("could not load shader: " + name);
             return nullptr;
         }
         asset->WaitUntilValid();
@@ -858,7 +858,7 @@ namespace sp::vulkan {
 
         auto reflection = spv_reflect::ShaderModule(asset->BufferSize(), asset->Buffer());
         if (reflection.GetResult() != SPV_REFLECT_RESULT_SUCCESS) {
-            Assert(false, "could not parse shader: " + name + " error: " + std::to_string(reflection.GetResult()));
+            Abort("could not parse shader: " + name + " error: " + std::to_string(reflection.GetResult()));
         }
 
         return make_shared<Shader>(name, std::move(shaderModule), std::move(reflection), newHash);

--- a/src/graphics/graphics/vulkan/Pipeline.cc
+++ b/src/graphics/graphics/vulkan/Pipeline.cc
@@ -116,7 +116,7 @@ namespace sp::vulkan {
                         Assert(desc->image.dim != SpvDimBuffer, "sampled buffers are unimplemented");
                         setInfo.sampledImagesMask |= (1 << binding);
                     } else {
-                        Assert(false, "unsupported SpvReflectDescriptorType " + std::to_string(type));
+                        Abort("unsupported SpvReflectDescriptorType " + std::to_string(type));
                     }
                 }
             }

--- a/src/physx/physx/ConvexHull.cc
+++ b/src/physx/physx/ConvexHull.cc
@@ -63,7 +63,7 @@ namespace sp {
             indices = indicesCopy;
             break;
         default:
-            Assert(false, "invalid index component type");
+            Abort("invalid index component type");
             break;
         }
 
@@ -175,7 +175,7 @@ namespace sp {
                 index = *(const uint16 *)(indices + i * indexAttrib.byteStride);
                 break;
             default:
-                Assert(false, "invalid index component type");
+                Abort("invalid index component type");
                 break;
             }
 

--- a/src/physx/physx/PhysxManager.cc
+++ b/src/physx/physx/PhysxManager.cc
@@ -442,7 +442,7 @@ namespace sp {
                         geom.scale = PxMeshScale(GlmVec3ToPxVec3(scale));
                         shapes[i]->setGeometry(geom);
                     } else {
-                        Assert(false, "Physx geometry type not implemented");
+                        Abort("Physx geometry type not implemented");
                     }
                 }
                 ph.scale = scale;

--- a/tests/tests.hh
+++ b/tests/tests.hh
@@ -24,6 +24,10 @@ inline std::ostream &operator<<(std::ostream &out, const std::pair<Ta, Tb> &v) {
     return out << "(" << v.first << ", " << v.second << ")";
 }
 
+#ifdef Assert
+    #undef Assert
+#endif
+
 namespace testing {
     extern std::vector<std::function<void()>> registeredTests;
 


### PR DESCRIPTION
Previously, every call to Assert was calling malloc to convert the `const char *` argument to a `const string &` value.

Using a macro for Assert also means that any dynamic string concatenation or to_string calls won't happen unless the assertion fails.