### PR TITLE
Move all rendering to RenderGraph

### DIFF
--- a/shaders/vulkan/screen_cover.frag
+++ b/shaders/vulkan/screen_cover.frag
@@ -1,0 +1,9 @@
+#version 450
+
+layout(binding = 0) uniform sampler2D tex;
+layout(location = 0) in vec2 inTexCoord;
+layout(location = 0) out vec4 outFragColor;
+
+void main() {
+	outFragColor = texture(tex, inTexCoord);
+}

--- a/shaders/vulkan/screen_cover.vert
+++ b/shaders/vulkan/screen_cover.vert
@@ -1,0 +1,28 @@
+#version 450
+
+layout(location = 0) out vec2 outTexCoord;
+
+out gl_PerVertex
+{
+	vec4 gl_Position;
+};
+
+vec2 positions[3] = vec2[](
+    vec2(-2, -1),
+    vec2(2, -1),
+    vec2(0, 3)
+);
+
+vec2 uvs[3] = vec2[](
+    vec2(-0.5, 1),
+    vec2(1.5, 1),
+    vec2(0.5, -1)
+);
+
+const bool flipped = false;
+
+void main() {
+	outTexCoord = uvs[gl_VertexIndex];
+    if (flipped) outTexCoord.y = 1 - outTexCoord.y;
+    gl_Position = vec4(positions[gl_VertexIndex], 0.0, 1.0);
+}

--- a/src/graphics/graphics/vulkan/CommandContext.hh
+++ b/src/graphics/graphics/vulkan/CommandContext.hh
@@ -60,8 +60,13 @@ namespace sp::vulkan {
         void BeginRenderPass(const RenderPassInfo &info);
         void EndRenderPass();
 
-        void Draw(uint32 vertexes, uint32 instances, int32 firstVertex, uint32 firstInstance);
-        void DrawIndexed(uint32 indexes, uint32 instances, uint32 firstIndex, int32 vertexOffset, uint32 firstInstance);
+        void Draw(uint32 vertexes, uint32 instances = 1, int32 firstVertex = 0, uint32 firstInstance = 0);
+        void DrawIndexed(uint32 indexes,
+                         uint32 instances = 1,
+                         uint32 firstIndex = 0,
+                         int32 vertexOffset = 0,
+                         uint32 firstInstance = 0);
+        void DrawScreenCover(const ImageViewPtr &view = nullptr);
 
         void ImageBarrier(
             const ImagePtr &image,
@@ -172,8 +177,7 @@ namespace sp::vulkan {
         // Buffer is stored in a pool for this frame, and reused in later frames.
         BufferPtr AllocUniformBuffer(uint32 set, uint32 binding, vk::DeviceSize size);
 
-        // Returns a CPU mapped pointer to the GPU buffer, which is valid
-        // at least until the CommandContext is submitted
+        // Returns a CPU mapped pointer to the GPU buffer, valid at least until the CommandContext is submitted
         template<typename T>
         T *AllocUniformData(uint32 set, uint32 binding, uint32 count = 1) {
             auto buffer = AllocUniformBuffer(set, binding, sizeof(T) * count);

--- a/src/graphics/graphics/vulkan/DeviceContext.cc
+++ b/src/graphics/graphics/vulkan/DeviceContext.cc
@@ -359,10 +359,10 @@ namespace sp::vulkan {
         vk::SurfaceFormatKHR surfaceFormat = surfaceFormats[0];
         for (auto &format : surfaceFormats) {
             if (format.colorSpace == vk::ColorSpaceKHR::eSrgbNonlinear) {
-                if (format.format == vk::Format::eB8G8R8A8Srgb) {
+                if (format.format == vk::Format::eR8G8B8A8Srgb) {
                     surfaceFormat = format;
                     break;
-                } else if (format.format == vk::Format::eR8G8B8A8Srgb) {
+                } else if (format.format == vk::Format::eB8G8R8A8Srgb) {
                     surfaceFormat = format;
                     break;
                 }
@@ -401,13 +401,6 @@ namespace sp::vulkan {
             imageViewInfo.swapchainLayout = vk::ImageLayout::ePresentSrcKHR;
             swapchainImageContexts[i].imageView = CreateImageView(imageViewInfo);
         }
-
-        vk::ImageCreateInfo depthImageInfo;
-        depthImageInfo.imageType = vk::ImageType::e2D;
-        depthImageInfo.format = vk::Format::eD24UnormS8Uint;
-        depthImageInfo.usage = vk::ImageUsageFlagBits::eDepthStencilAttachment;
-        depthImageInfo.extent = vk::Extent3D(swapchainExtent.width, swapchainExtent.height, 1);
-        depthImageView = CreateImageAndView(depthImageInfo, {});
     }
 
     void DeviceContext::RecreateSwapchain() {
@@ -834,7 +827,7 @@ namespace sp::vulkan {
         }
 
         // Each mip has now been transitioned to TransferSrc.
-        image->SetLayout(vk::ImageLayout::eTransferSrcOptimal);
+        image->SetLayout(vk::ImageLayout::eUndefined, vk::ImageLayout::eTransferSrcOptimal);
 
         graphicsCmd->ImageBarrier(image,
                                   vk::ImageLayout::eTransferSrcOptimal,
@@ -1015,11 +1008,8 @@ namespace sp::vulkan {
         return pipelinePool->GetGraphicsPipeline(input);
     }
 
-    RenderPassInfo DeviceContext::SwapchainRenderPassInfo(bool depth, bool stencil) {
-        RenderPassInfo info;
-        info.PushColorAttachment(SwapchainImage().imageView, LoadOp::Clear, StoreOp::Store, {0.0f, 1.0f, 0.0f, 1.0f});
-        if (depth) info.SetDepthStencilAttachment(depthImageView, LoadOp::Clear, StoreOp::DontCare);
-        return info;
+    ImageViewPtr DeviceContext::SwapchainImageView() {
+        return SwapchainImage().imageView;
     }
 
     shared_ptr<RenderPass> DeviceContext::GetRenderPass(const RenderPassInfo &info) {

--- a/src/graphics/graphics/vulkan/DeviceContext.hh
+++ b/src/graphics/graphics/vulkan/DeviceContext.hh
@@ -104,14 +104,13 @@ namespace sp::vulkan {
                                         const uint8 *srcData = nullptr,
                                         size_t srcDataSize = 0,
                                         bool genMipmap = false);
+        ImageViewPtr SwapchainImageView();
         vk::Sampler GetSampler(SamplerType type);
         vk::Sampler GetSampler(const vk::SamplerCreateInfo &info);
 
         RenderTargetPtr GetRenderTarget(const RenderTargetDesc &desc);
 
         shared_ptr<GpuTexture> LoadTexture(shared_ptr<const sp::Image> image, bool genMipmap = true) override;
-
-        RenderPassInfo SwapchainRenderPassInfo(bool depth = false, bool stencil = false);
 
         ShaderHandle LoadShader(const string &name);
         shared_ptr<Shader> GetShader(ShaderHandle handle) const;
@@ -226,8 +225,6 @@ namespace sp::vulkan {
         FrameContext &Frame() {
             return frameContexts[frameIndex];
         }
-
-        ImageViewPtr depthImageView; // TODO: move to render target pool
 
         robin_hood::unordered_map<string, ShaderHandle> shaderHandles;
         vector<shared_ptr<Shader>> shaders; // indexed by ShaderHandle minus 1

--- a/src/graphics/graphics/vulkan/GuiRenderer.hh
+++ b/src/graphics/graphics/vulkan/GuiRenderer.hh
@@ -14,7 +14,7 @@ namespace sp::vulkan {
     class GuiRenderer : public NonCopyable {
     public:
         GuiRenderer(DeviceContext &device, GuiManager &manager);
-        void Render(const CommandContextPtr &cmd, vk::Rect2D viewport);
+        void Render(CommandContext &cmd, vk::Rect2D viewport);
 
     private:
         double lastTime = 0.0;

--- a/src/graphics/graphics/vulkan/Image.cc
+++ b/src/graphics/graphics/vulkan/Image.cc
@@ -27,6 +27,12 @@ namespace sp::vulkan {
         }
     }
 
+    void Image::SetLayout(vk::ImageLayout oldLayout, vk::ImageLayout newLayout) {
+        Assert(oldLayout == vk::ImageLayout::eUndefined || oldLayout == lastLayout,
+               "image had layout: " + vk::to_string(lastLayout) + ", expected: " + vk::to_string(oldLayout));
+        lastLayout = newLayout;
+    }
+
     vk::Format FormatFromTraits(uint32 components, uint32 bits, bool preferSrgb, bool logErrors) {
         if (bits != 8 && bits != 16) {
             if (logErrors) Errorf("can't infer format with bits=%d", bits);

--- a/src/graphics/graphics/vulkan/Image.hh
+++ b/src/graphics/graphics/vulkan/Image.hh
@@ -60,9 +60,7 @@ namespace sp::vulkan {
             return lastLayout;
         }
 
-        void SetLayout(vk::ImageLayout currentLayout) {
-            lastLayout = currentLayout;
-        }
+        void SetLayout(vk::ImageLayout oldLayout, vk::ImageLayout newLayout);
 
     private:
         vk::Image image;

--- a/src/graphics/graphics/vulkan/RenderGraph.cc
+++ b/src/graphics/graphics/vulkan/RenderGraph.cc
@@ -43,6 +43,22 @@ namespace sp::vulkan {
         return invalidResource;
     }
 
+    void RenderGraph::SetTargetImageView(string_view name, ImageViewPtr view) {
+        auto &res = resources.GetResourceByName(name);
+        Assert(res.renderTargetDesc.extent == view->Extent(), "image extent mismatch");
+
+        auto resFormat = res.renderTargetDesc.format;
+        auto viewFormat = view->Format();
+        Assert(FormatComponentCount(resFormat) == FormatComponentCount(viewFormat), "image component count mismatch");
+        Assert(FormatByteSize(resFormat) == FormatByteSize(viewFormat), "image component size mismatch");
+
+        Assert(view->BaseArrayLayer() == 0, "view can't target a specific layer");
+        Assert(res.renderTargetDesc.arrayLayers == view->Image()->ArrayLayers(), "image array mismatch");
+
+        resources.ResizeBeforeExecute();
+        resources.renderTargets[res.id] = make_shared<RenderTarget>(res.renderTargetDesc, view, ~0u);
+    }
+
     void RenderGraph::Execute() {
         resources.ResizeBeforeExecute();
 

--- a/src/graphics/graphics/vulkan/RenderGraph.hh
+++ b/src/graphics/graphics/vulkan/RenderGraph.hh
@@ -129,6 +129,8 @@ namespace sp::vulkan {
             return pass->data;
         }
 
+        void SetTargetImageView(string_view name, ImageViewPtr view);
+
         void Execute();
 
     private:

--- a/src/graphics/graphics/vulkan/RenderPass.cc
+++ b/src/graphics/graphics/vulkan/RenderPass.cc
@@ -40,6 +40,8 @@ namespace sp::vulkan {
             colorAttachmentRef.attachment = i;
             colorAttachmentRef.layout = vk::ImageLayout::eColorAttachmentOptimal;
 
+            initialLayouts[attachmentCount] = colorAttachment.initialLayout;
+            finalLayouts[attachmentCount] = colorAttachment.finalLayout;
             attachmentCount++;
         }
 
@@ -65,6 +67,8 @@ namespace sp::vulkan {
             depthAttachmentRef.attachment = attachmentCount;
             depthAttachmentRef.layout = vk::ImageLayout::eDepthStencilAttachmentOptimal;
 
+            initialLayouts[attachmentCount] = depthStencilAttachment.initialLayout;
+            finalLayouts[attachmentCount] = depthStencilAttachment.finalLayout;
             attachmentCount++;
         }
 
@@ -106,6 +110,16 @@ namespace sp::vulkan {
         }
 
         uniqueHandle = device->createRenderPassUnique(renderPassInfo);
+    }
+
+    void RenderPass::RecordImplicitImageLayoutTransitions(const RenderPassInfo &info) {
+        for (uint32 i = 0; i < info.state.colorAttachmentCount; i++) {
+            info.colorAttachments[i]->Image()->SetLayout(initialLayouts[i], finalLayouts[i]);
+        }
+        if (info.HasDepthStencil()) {
+            auto i = info.state.colorAttachmentCount;
+            info.depthStencilAttachment->Image()->SetLayout(initialLayouts[i], finalLayouts[i]);
+        }
     }
 
     Framebuffer::Framebuffer(DeviceContext &device, const RenderPassInfo &info) {

--- a/src/graphics/graphics/vulkan/RenderPass.hh
+++ b/src/graphics/graphics/vulkan/RenderPass.hh
@@ -116,6 +116,12 @@ namespace sp::vulkan {
     class RenderPass : public WrappedUniqueHandle<vk::RenderPass> {
     public:
         RenderPass(DeviceContext &device, const RenderPassInfo &info);
+
+        // Updates the cached layout of the framebuffer attachment images
+        void RecordImplicitImageLayoutTransitions(const RenderPassInfo &info);
+
+    private:
+        std::array<vk::ImageLayout, MAX_COLOR_ATTACHMENTS + 1> initialLayouts, finalLayouts;
     };
 
     class Framebuffer : public WrappedUniqueHandle<vk::Framebuffer> {

--- a/src/graphics/graphics/vulkan/RenderTarget.cc
+++ b/src/graphics/graphics/vulkan/RenderTarget.cc
@@ -5,7 +5,9 @@
 
 namespace sp::vulkan {
     RenderTarget::~RenderTarget() {
-        Debugf("Destroying render target %d, size=%dx%d", poolIndex, desc.extent.width, desc.extent.height);
+        if (poolIndex != ~0u) {
+            Debugf("Destroying render target %d, size=%dx%d", poolIndex, desc.extent.width, desc.extent.height);
+        }
     }
 
     RenderTargetPtr RenderTargetManager::Get(const RenderTargetDesc &desc) {
@@ -25,7 +27,10 @@ namespace sp::vulkan {
         imageInfo.format = desc.format;
         imageInfo.usage = desc.usage;
 
-        auto imageView = device.CreateImageAndView(imageInfo, {});
+        ImageViewCreateInfo viewInfo;
+        viewInfo.defaultSampler = device.GetSampler(SamplerType::BilinearTiled);
+
+        auto imageView = device.CreateImageAndView(imageInfo, viewInfo);
         auto ptr = make_shared<RenderTarget>(desc, imageView, pool.size());
 
         pool.push_back(ptr);

--- a/src/graphics/graphics/vulkan/Renderer.cc
+++ b/src/graphics/graphics/vulkan/Renderer.cc
@@ -16,8 +16,6 @@ namespace sp::vulkan {
     }
 
     void Renderer::RenderPass(CommandContext &cmd, const ecs::View &view, DrawLock lock) {
-        cmd.SetDefaultOpaqueState();
-
         cmd.SetShader(ShaderStage::Vertex, "test.vert");
         cmd.SetShader(ShaderStage::Fragment, "test.frag");
 


### PR DESCRIPTION
Also:
- track image layouts as they're implicitly transitioned by render passes
- add DrawScreenCover to CommandContext
- add a way to render directly to the swapchain image through a RenderGraphResource
- fix issue rendering a single color attachment that doesn't specify to clear the attachment
