### PR TITLE
Automatically determine barriers in RenderGraph

### DIFF
--- a/src/graphics/graphics/vulkan/core/RenderGraph.cc
+++ b/src/graphics/graphics/vulkan/core/RenderGraph.cc
@@ -1,5 +1,6 @@
 #include "RenderGraph.hh"
 
+#include "CommandContext.hh"
 #include "DeviceContext.hh"
 #include "core/Logging.hh"
 
@@ -9,7 +10,13 @@ namespace sp::vulkan {
         renderTargets.resize(resources.size());
     }
 
-    RenderTargetPtr RenderGraphResources::GetRenderTarget(const RenderGraphResource &res) {
+    RenderTargetPtr RenderGraphResources::GetRenderTarget(string_view name) {
+        return GetRenderTarget(GetID(name));
+    }
+
+    RenderTargetPtr RenderGraphResources::GetRenderTarget(uint32 id) {
+        if (id >= resources.size()) return nullptr;
+        auto &res = resources[id];
         Assert(res.type == RenderGraphResource::Type::RenderTarget, "resources is not a render target");
         auto &target = renderTargets[res.id];
         if (!target) target = device.GetRenderTarget(res.renderTargetDesc);
@@ -36,9 +43,8 @@ namespace sp::vulkan {
     }
 
     const RenderGraphResource &RenderGraphResources::GetResourceByName(string_view name) const {
-        for (size_t i = 0; i < names.size(); i++) {
-            if (names[i] == name) return resources[i];
-        }
+        auto id = GetID(name);
+        if (id < resources.size()) return resources[id];
         static RenderGraphResource invalidResource = {};
         return invalidResource;
     }
@@ -63,20 +69,70 @@ namespace sp::vulkan {
         resources.ResizeBeforeExecute();
 
         for (auto &pass : passes) {
-            for (auto id : pass->dependencies) {
-                resources.IncrementRef(id);
+            for (auto &dep : pass->dependencies) {
+                resources.IncrementRef(dep.id);
             }
         }
 
         for (auto &pass : passes) {
             auto cmd = device.GetCommandContext();
+            AddPassBarriers(*cmd, pass.get());
             pass->Execute(resources, *cmd);
             device.Submit(cmd);
 
-            for (auto id : pass->dependencies) {
-                resources.DecrementRef(id);
+            for (auto &dep : pass->dependencies) {
+                resources.DecrementRef(dep.id);
             }
         }
         passes.clear();
+    }
+
+    void RenderGraph::AddPassBarriers(CommandContext &cmd, RenderGraphPassBase *pass) {
+        for (auto &dep : pass->dependencies) {
+            if (dep.access.layout == vk::ImageLayout::eUndefined) continue;
+
+            auto &res = resources.resources[dep.id];
+            Assert(res.type == RenderGraphResource::Type::RenderTarget, "resource type must be RenderTarget");
+
+            auto image = resources.GetRenderTarget(dep.id)->ImageView()->Image();
+            cmd.ImageBarrier(image,
+                             image->LastLayout(),
+                             dep.access.layout,
+                             vk::PipelineStageFlagBits::eColorAttachmentOutput, // TODO: infer these
+                             vk::AccessFlagBits::eColorAttachmentWrite,
+                             dep.access.stages,
+                             dep.access.access);
+        }
+
+        for (auto id : pass->outputs) {
+            // assume pass doesn't depend on one of its outputs (e.g. blending), TODO: implement
+            auto &res = resources.resources[id];
+
+            Assert(res.type == RenderGraphResource::Type::RenderTarget, "resource type must be RenderTarget");
+
+            auto view = resources.GetRenderTarget(id)->ImageView();
+            auto image = view->Image();
+            if (view->IsSwapchain()) continue; // barrier handled by RenderPass implicitly
+
+            if (res.renderTargetDesc.usage & vk::ImageUsageFlagBits::eColorAttachment) {
+                if (image->LastLayout() == vk::ImageLayout::eColorAttachmentOptimal) continue;
+                cmd.ImageBarrier(image,
+                                 vk::ImageLayout::eUndefined,
+                                 vk::ImageLayout::eColorAttachmentOptimal,
+                                 vk::PipelineStageFlagBits::eBottomOfPipe,
+                                 {},
+                                 vk::PipelineStageFlagBits::eColorAttachmentOutput,
+                                 vk::AccessFlagBits::eColorAttachmentWrite);
+            } else if (res.renderTargetDesc.usage & vk::ImageUsageFlagBits::eDepthStencilAttachment) {
+                if (image->LastLayout() == vk::ImageLayout::eDepthAttachmentOptimal) continue;
+                cmd.ImageBarrier(image,
+                                 vk::ImageLayout::eUndefined,
+                                 vk::ImageLayout::eDepthAttachmentOptimal,
+                                 vk::PipelineStageFlagBits::eBottomOfPipe,
+                                 {},
+                                 vk::PipelineStageFlagBits::eEarlyFragmentTests,
+                                 vk::AccessFlagBits::eDepthStencilAttachmentWrite);
+            }
+        }
     }
 } // namespace sp::vulkan

--- a/src/graphics/graphics/vulkan/core/RenderGraph.hh
+++ b/src/graphics/graphics/vulkan/core/RenderGraph.hh
@@ -2,6 +2,8 @@
 #include "RenderTarget.hh"
 #include "core/StackVector.hh"
 
+#include <robin_hood.h>
+
 namespace sp::vulkan {
     struct RenderGraphResource {
         enum class Type {
@@ -19,13 +21,27 @@ namespace sp::vulkan {
         };
     };
 
+    struct RenderGraphResourceAccess {
+        vk::PipelineStageFlags stages = {};
+        vk::AccessFlags access = {};
+        vk::ImageLayout layout = vk::ImageLayout::eUndefined;
+    };
+
     class RenderGraphResources {
     public:
         RenderGraphResources(DeviceContext &device) : device(device) {}
 
-        RenderTargetPtr GetRenderTarget(const RenderGraphResource &res);
+        RenderTargetPtr GetRenderTarget(uint32 id);
+        RenderTargetPtr GetRenderTarget(string_view name);
 
         const RenderGraphResource &GetResourceByName(string_view name) const;
+
+        uint32 GetID(string_view name) const {
+            Assert(name.data()[name.size()] == '\0', "string_view is not null terminated");
+            auto it = names.find(name.data());
+            if (it == names.end()) return ~0u;
+            return it->second;
+        }
 
     private:
         friend class RenderGraph;
@@ -36,19 +52,32 @@ namespace sp::vulkan {
         void DecrementRef(uint32 id);
 
         void Register(string_view name, RenderGraphResource &resource) {
-            // Returns ID used to populate a RenderGraphResource
             resource.id = (uint32)resources.size();
             resources.push_back(resource);
-            names.push_back(name);
+
+            Assert(name.data()[name.size()] == '\0', "string_view is not null terminated");
+            auto &nameID = names[name.data()];
+            Assert(!nameID, "resource already registered");
+            nameID = resource.id;
+        }
+
+        RenderGraphResource &GetResourceRef(uint32 id) {
+            Assert(id < resources.size(), "resource ID " + std::to_string(id) + " is invalid");
+            return resources[id];
         }
 
         DeviceContext &device;
-        vector<string_view> names;
+        robin_hood::unordered_flat_map<string, uint32> names;
         vector<RenderGraphResource> resources;
 
         // Built during execution
         vector<uint32> refCounts;
         vector<RenderTargetPtr> renderTargets;
+    };
+
+    struct RenderGraphResourceDependency {
+        RenderGraphResourceAccess access;
+        uint32 id;
     };
 
     class RenderGraphPassBase {
@@ -57,8 +86,8 @@ namespace sp::vulkan {
         virtual ~RenderGraphPassBase() {}
         virtual void Execute(RenderGraphResources &resources, CommandContext &cmd) = 0;
 
-        void AddDependency(const RenderGraphResource &res) {
-            dependencies.push(res.id);
+        void AddDependency(const RenderGraphResourceAccess &access, const RenderGraphResource &res) {
+            dependencies.push({access, res.id});
         }
 
         void AddOutput(const RenderGraphResource &res) {
@@ -68,20 +97,18 @@ namespace sp::vulkan {
     private:
         friend class RenderGraph;
         string_view name;
-        StackVector<uint32, 32> dependencies;
+        StackVector<RenderGraphResourceDependency, 16> dependencies;
         StackVector<uint32, 16> outputs;
     };
 
-    template<typename DataType, typename ExecuteFunc>
+    template<typename ExecuteFunc>
     class RenderGraphPass : public RenderGraphPassBase {
     public:
         RenderGraphPass(string_view name, ExecuteFunc &executeFunc)
             : RenderGraphPassBase(name), executeFunc(executeFunc) {}
 
-        DataType data;
-
         void Execute(RenderGraphResources &resources, CommandContext &cmd) override {
-            executeFunc(resources, cmd, data);
+            executeFunc(resources, cmd);
         }
 
     private:
@@ -93,9 +120,32 @@ namespace sp::vulkan {
         RenderGraphPassBuilder(RenderGraphResources &resources, RenderGraphPassBase &pass)
             : resources(resources), pass(pass) {}
 
-        RenderGraphResource Read(const RenderGraphResource &input) {
-            pass.AddDependency(input);
-            return input;
+        void ShaderRead(string_view name) {
+            ShaderRead(resources.GetID(name));
+        }
+        void ShaderRead(uint32 id) {
+            auto &resource = resources.GetResourceRef(id);
+            resource.renderTargetDesc.usage |= vk::ImageUsageFlagBits::eSampled;
+            RenderGraphResourceAccess access = {
+                vk::PipelineStageFlagBits::eFragmentShader,
+                vk::AccessFlagBits::eShaderRead,
+                vk::ImageLayout::eShaderReadOnlyOptimal,
+            };
+            pass.AddDependency(access, resource);
+        }
+
+        void TransferRead(string_view name) {
+            TransferRead(resources.GetID(name));
+        }
+        void TransferRead(uint32 id) {
+            auto &resource = resources.GetResourceRef(id);
+            resource.renderTargetDesc.usage |= vk::ImageUsageFlagBits::eTransferSrc;
+            RenderGraphResourceAccess access = {
+                vk::PipelineStageFlagBits::eTransfer,
+                vk::AccessFlagBits::eTransferRead,
+                vk::ImageLayout::eTransferSrcOptimal,
+            };
+            pass.AddDependency(access, resource);
         }
 
         RenderGraphResource GetResourceByName(string_view name) {
@@ -118,15 +168,14 @@ namespace sp::vulkan {
     public:
         RenderGraph(DeviceContext &device) : device(device), resources(device) {}
 
-        template<typename DataType, typename SetupFunc, typename ExecuteFunc>
-        DataType &AddPass(string_view name, SetupFunc setupFunc, ExecuteFunc executeFunc) {
+        template<typename SetupFunc, typename ExecuteFunc>
+        void AddPass(string_view name, SetupFunc setupFunc, ExecuteFunc executeFunc) {
             static_assert(sizeof(ExecuteFunc) < 1024, "execute callback must capture less than 1kB");
 
-            auto pass = make_shared<RenderGraphPass<DataType, ExecuteFunc>>(name, executeFunc);
+            auto pass = make_shared<RenderGraphPass<ExecuteFunc>>(name, executeFunc);
             RenderGraphPassBuilder builder(resources, *pass);
-            setupFunc(builder, pass->data);
+            setupFunc(builder);
             passes.push_back(pass);
-            return pass->data;
         }
 
         void SetTargetImageView(string_view name, ImageViewPtr view);
@@ -134,6 +183,8 @@ namespace sp::vulkan {
         void Execute();
 
     private:
+        void AddPassBarriers(CommandContext &cmd, RenderGraphPassBase *pass);
+
         DeviceContext &device;
         RenderGraphResources resources;
         vector<shared_ptr<RenderGraphPassBase>> passes;


### PR DESCRIPTION
Partial implementation, that covers our current use cases. See TODOs for next steps.