### PR TITLE
Reuse semaphores and fences

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -131,6 +131,11 @@
         "editor.insertSpaces": true,
         "editor.tabSize": 4
     },
+    "[glsl]": {
+        "editor.detectIndentation": false,
+        "editor.insertSpaces": false,
+        "editor.tabSize": 4
+    },
     "[cmake]": {
         "editor.detectIndentation": false,
         "editor.insertSpaces": true,

--- a/src/core/core/Hashing.hh
+++ b/src/core/core/Hashing.hh
@@ -67,11 +67,9 @@ namespace sp {
             const std::string_view view = rhs;
             return lhs == view;
         }
-
         bool operator()(const char *lhs, const std::string &rhs) const {
             return std::strcmp(lhs, rhs.c_str()) == 0;
         }
-
         bool operator()(const std::string &lhs, const std::string &rhs) const {
             return lhs == rhs;
         }

--- a/src/graphics/graphics/vulkan/core/CMakeLists.txt
+++ b/src/graphics/graphics/vulkan/core/CMakeLists.txt
@@ -2,6 +2,7 @@ target_sources(${PROJECT_GRAPHICS_VULKAN_CORE_LIB} PRIVATE
     CommandContext.cc
     Common.cc
     DeviceContext.cc
+    HandlePool.cc
     Image.cc
     Memory.cc
     Model.cc

--- a/src/graphics/graphics/vulkan/core/HandlePool.cc
+++ b/src/graphics/graphics/vulkan/core/HandlePool.cc
@@ -1,0 +1,5 @@
+#include "HandlePool.hh"
+
+namespace sp::vulkan {
+    vector<bool> HandlePoolExists;
+}

--- a/src/graphics/graphics/vulkan/core/HandlePool.hh
+++ b/src/graphics/graphics/vulkan/core/HandlePool.hh
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "graphics/vulkan/core/Common.hh"
+
+namespace sp::vulkan {
+    template<typename HandleType>
+    class SharedHandle {
+    public:
+        SharedHandle() {}
+        SharedHandle(std::nullptr_t) {}
+
+        SharedHandle(HandleType handle, vector<SharedHandle<HandleType>> &freeList)
+            : handle(handle), freeList(&freeList) {
+            ptr = make_shared<bool>(true);
+        }
+
+        ~SharedHandle() {
+            if (ptr && ptr.use_count() == 1) { freeList->push_back(*this); }
+        }
+
+        operator HandleType() {
+            return handle;
+        }
+
+        operator bool() {
+            return !!ptr;
+        }
+
+    private:
+        HandleType handle = {};
+        vector<SharedHandle<HandleType>> *freeList = nullptr;
+        shared_ptr<bool> ptr = {}; // used only for refcounting this object
+    };
+
+    template<typename HandleType>
+    class HandlePool {
+    public:
+        HandlePool(std::function<HandleType()> createObject,
+                   std::function<void(HandleType)> destroyObject,
+                   std::function<void(HandleType)> resetObject = {})
+            : createObject(createObject), destroyObject(destroyObject), resetObject(resetObject) {}
+
+        ~HandlePool() {
+            Assert(freeObjects.size() == totalObjects, "some objects weren't freed before the pool");
+            for (auto object : freeObjects) {
+                destroyObject(object);
+            }
+        }
+
+        SharedHandle<HandleType> Get() {
+            if (!freeObjects.empty()) {
+                SharedHandle<HandleType> sharedHandle = freeObjects.back();
+                freeObjects.pop_back();
+                if (resetObject) resetObject(sharedHandle);
+                return sharedHandle;
+            }
+
+            HandleType object = createObject();
+            totalObjects++;
+            return {object, freeObjects};
+        }
+
+    private:
+        std::function<HandleType()> createObject;
+        std::function<void(HandleType)> destroyObject, resetObject;
+        vector<SharedHandle<HandleType>> freeObjects;
+        size_t totalObjects = 0;
+    };
+} // namespace sp::vulkan


### PR DESCRIPTION
Part of #105.

This adds `HandlePool<HandleType>`, a class to hold any reusable Vulkan resources that are handles. `HandlePool<HandleType>::Get()` returns `SharedHandle<HandleType>`. This is a refcounted object that will return itself to the pool when all external references are gone. A subsequent call to `Get()` will return the previously used `SharedHandle`.

It is extremely important that the object inside the SharedHandle is possible to reuse before it's returned to the pool. The `resetObject` function can be used to clean up the object before it's reused.

Semaphores are a bit tricky - there's no way to reset their state. The application must ensure the semaphore is not signalled or waiting when the last SharedHandle pointing to it is destroyed. This is currently enforced by passing every temporary semaphore to `PushInFlightObject`, which waits for the fence corresponding to the last use of the semaphore to be complete.