### PR TITLE
Use UniqueID to avoid hash collisions upon pointer reuse

### DIFF
--- a/src/graphics/graphics/vulkan/core/CommandContext.hh
+++ b/src/graphics/graphics/vulkan/core/CommandContext.hh
@@ -212,10 +212,6 @@ namespace sp::vulkan {
 
         void SetTexture(uint32 set, uint32 binding, const ImageViewPtr &view);
         void SetTexture(uint32 set, uint32 binding, const ImageView *view);
-        void SetTexture(uint32 set,
-            uint32 binding,
-            const vk::ImageView &view,
-            vk::ImageLayout layout = vk::ImageLayout::eShaderReadOnlyOptimal);
         void SetSampler(uint32 set, uint32 binding, const vk::Sampler &sampler);
 
         void SetUniformBuffer(uint32 set, uint32 binding, const BufferPtr &buffer);

--- a/src/graphics/graphics/vulkan/core/Common.hh
+++ b/src/graphics/graphics/vulkan/core/Common.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <core/Common.hh>
+#include <graphics/vulkan/core/UniqueID.hh>
 #include <string>
 #include <vulkan/vulkan.hpp>
 

--- a/src/graphics/graphics/vulkan/core/DeviceContext.hh
+++ b/src/graphics/graphics/vulkan/core/DeviceContext.hh
@@ -6,7 +6,6 @@
 #include "graphics/vulkan/core/HandlePool.hh"
 #include "graphics/vulkan/core/Memory.hh"
 #include "graphics/vulkan/core/RenderPass.hh"
-#include "graphics/vulkan/core/UniqueID.hh"
 
 #include <robin_hood.h>
 #include <variant>
@@ -130,10 +129,6 @@ namespace sp::vulkan {
         using TemporaryObject = std::variant<BufferPtr, ImageViewPtr, SharedHandle<vk::Semaphore>>;
         SharedHandle<vk::Fence> PushInFlightObject(TemporaryObject object, SharedHandle<vk::Fence> fence = nullptr);
 
-        UniqueID NextUniqueID() {
-            return ++lastUniqueID;
-        }
-
         const vk::PhysicalDeviceLimits &Limits() const {
             return physicalDeviceProperties.limits;
         }
@@ -251,7 +246,5 @@ namespace sp::vulkan {
         GLFWwindow *window = nullptr;
 
         unique_ptr<CFuncCollection> funcs;
-
-        UniqueID lastUniqueID = 0;
     };
 } // namespace sp::vulkan

--- a/src/graphics/graphics/vulkan/core/Image.hh
+++ b/src/graphics/graphics/vulkan/core/Image.hh
@@ -136,7 +136,7 @@ namespace sp::vulkan {
         vk::ImageUsageFlags usage = {}; // defaults to image's usage
     };
 
-    class ImageView final : public WrappedUniqueHandle<vk::ImageView>, public GpuTexture {
+    class ImageView final : public WrappedUniqueHandle<vk::ImageView>, public GpuTexture, public HasUniqueID {
     public:
         ImageView() {}
 

--- a/src/graphics/graphics/vulkan/core/Memory.hh
+++ b/src/graphics/graphics/vulkan/core/Memory.hh
@@ -41,7 +41,7 @@ namespace sp::vulkan {
         BufferType type;
     };
 
-    class UniqueMemory : public NonCopyable {
+    class UniqueMemory : public NonCopyable, public HasUniqueID {
     public:
         UniqueMemory() = delete;
         UniqueMemory(VmaAllocator allocator) : allocator(allocator), allocation(nullptr) {}

--- a/src/graphics/graphics/vulkan/core/Pipeline.cc
+++ b/src/graphics/graphics/vulkan/core/Pipeline.cc
@@ -182,9 +182,8 @@ namespace sp::vulkan {
 
         ForEachBit(setLayout.sampledImagesMask | setLayout.storageImagesMask, [&](uint32 binding) {
             for (uint32 i = 0; i < setLayout.descriptorCount[binding]; i++) {
-                // TODO: use UniqueID to avoid collisions upon pointer reuse
+                hash_combine(hash, bindings[binding + i].uniqueID);
                 hash_combine(hash, bindings[binding + i].image.imageView);
-                // TODO: use UniqueID to avoid collisions upon pointer reuse
                 hash_combine(hash, bindings[binding + i].image.sampler);
                 hash_combine(hash, bindings[binding + i].image.imageLayout);
             }
@@ -192,7 +191,7 @@ namespace sp::vulkan {
 
         ForEachBit(setLayout.uniformBuffersMask, [&](uint32 binding) {
             for (uint32 i = 0; i < setLayout.descriptorCount[binding]; i++) {
-                // TODO: use UniqueID to avoid collisions upon pointer reuse
+                hash_combine(hash, bindings[binding + i].uniqueID);
                 hash_combine(hash, bindings[binding + i].buffer.buffer);
                 hash_combine(hash, bindings[binding + i].buffer.offset);
                 hash_combine(hash, bindings[binding + i].buffer.range);
@@ -211,7 +210,7 @@ namespace sp::vulkan {
 
         PipelineKey key;
         key.input.state = compile.state;
-        key.input.renderPass = compile.renderPass ? **compile.renderPass : nullptr;
+        key.input.renderPassID = compile.renderPass ? compile.renderPass->GetUniqueID() : 0;
         key.input.shaderHashes = GetShaderHashes(shaders);
 
         for (size_t s = 0; s < (size_t)ShaderStage::Count; s++) {

--- a/src/graphics/graphics/vulkan/core/Pipeline.hh
+++ b/src/graphics/graphics/vulkan/core/Pipeline.hh
@@ -132,9 +132,7 @@ namespace sp::vulkan {
 
         struct PipelineKeyData {
             ShaderHashSet shaderHashes;
-            // TODO: use UniqueID to avoid collisions upon pointer reuse
-            // TODO: hash RenderPass important fields instead?
-            VkRenderPass renderPass;
+            UniqueID renderPassID;
             PipelineStaticState state;
         };
 

--- a/src/graphics/graphics/vulkan/core/RenderPass.cc
+++ b/src/graphics/graphics/vulkan/core/RenderPass.cc
@@ -172,11 +172,11 @@ namespace sp::vulkan {
         key.input.renderPass = info.state;
 
         for (uint32 i = 0; i < info.state.colorAttachmentCount; i++) {
-            auto image = info.colorAttachments[i];
-            Assert(!!image, "render pass is missing a color image");
-            key.input.imageViews[i] = *image;
+            auto imageView = info.colorAttachments[i];
+            Assert(!!imageView, "render pass is missing a color image");
+            key.input.imageViewIDs[i] = imageView->GetUniqueID();
 
-            auto extent = image->Extent();
+            auto extent = imageView->Extent();
             key.input.extents[i].width = extent.width;
             key.input.extents[i].height = extent.height;
         }
@@ -184,7 +184,7 @@ namespace sp::vulkan {
         if (info.HasDepthStencil()) {
             auto image = info.depthStencilAttachment;
             Assert(!!image, "render pass is missing depth image");
-            key.input.imageViews[MAX_COLOR_ATTACHMENTS] = *image;
+            key.input.imageViewIDs[MAX_COLOR_ATTACHMENTS] = image->GetUniqueID();
         }
 
         auto &fb = framebuffers[key];

--- a/src/graphics/graphics/vulkan/core/RenderPass.hh
+++ b/src/graphics/graphics/vulkan/core/RenderPass.hh
@@ -141,7 +141,7 @@ namespace sp::vulkan {
         }
     };
 
-    class RenderPass : public WrappedUniqueHandle<vk::RenderPass> {
+    class RenderPass : public WrappedUniqueHandle<vk::RenderPass>, public HasUniqueID {
     public:
         RenderPass(DeviceContext &device, const RenderPassInfo &info);
 
@@ -194,10 +194,7 @@ namespace sp::vulkan {
 
         struct FramebufferKeyData {
             RenderPassState renderPass;
-
-            // TODO: use UniqueID to avoid collisions upon pointer reuse
-            vk::ImageView imageViews[MAX_COLOR_ATTACHMENTS + 1];
-
+            UniqueID imageViewIDs[MAX_COLOR_ATTACHMENTS + 1];
             vk::Extent2D extents[MAX_COLOR_ATTACHMENTS + 1];
         };
 

--- a/src/graphics/graphics/vulkan/core/Shader.hh
+++ b/src/graphics/graphics/vulkan/core/Shader.hh
@@ -59,6 +59,7 @@ namespace sp::vulkan {
             VkDescriptorImageInfo image;
         };
         vk::DeviceSize offset;
+        UniqueID uniqueID = 0;
     };
 
     struct DescriptorSetBindings {

--- a/src/graphics/graphics/vulkan/core/UniqueID.cc
+++ b/src/graphics/graphics/vulkan/core/UniqueID.cc
@@ -3,5 +3,10 @@
 #include "graphics/vulkan/core/DeviceContext.hh"
 
 namespace sp::vulkan {
-    HasUniqueID::HasUniqueID(DeviceContext &device) : uniqueID(device.NextUniqueID()) {}
+    static UniqueID NextUniqueID() {
+        static UniqueID lastUniqueID = 0;
+        return ++lastUniqueID;
+    }
+
+    HasUniqueID::HasUniqueID() : uniqueID(NextUniqueID()) {}
 } // namespace sp::vulkan

--- a/src/graphics/graphics/vulkan/core/UniqueID.hh
+++ b/src/graphics/graphics/vulkan/core/UniqueID.hh
@@ -9,7 +9,7 @@ namespace sp::vulkan {
 
     class HasUniqueID {
     public:
-        HasUniqueID(DeviceContext &device);
+        HasUniqueID();
 
         UniqueID GetUniqueID() const {
             return uniqueID;


### PR DESCRIPTION
Fixes subtle bugs, for example when a buffer is deleted, and a new one is created, a cached descriptor set may be used for it and cause buffer memory corruption.