### PR TITLE
Clearly separate frame scoped vs fence scoped CommandContexts

### DIFF
--- a/src/graphics/graphics/vulkan/core/PerfTimer.cc
+++ b/src/graphics/graphics/vulkan/core/PerfTimer.cc
@@ -115,7 +115,7 @@ namespace sp::vulkan {
         }
 
         if (frame.queryPool && frame.queryCount > 0) {
-            auto cmd = device->GetCommandContext();
+            auto cmd = device->GetFrameCommandContext();
             cmd->Raw().resetQueryPool(*frame.queryPool, 0, frame.queryCount);
             device->Submit(cmd);
             frame.queryOffset = 0;

--- a/src/graphics/graphics/vulkan/core/RenderGraph.cc
+++ b/src/graphics/graphics/vulkan/core/RenderGraph.cc
@@ -243,7 +243,7 @@ namespace sp::vulkan {
             }
 
             if (!cmd) {
-                if (isRenderPass || pass.ExecutesWithCommandContext()) cmd = device.GetCommandContext();
+                if (isRenderPass || pass.ExecutesWithCommandContext()) cmd = device.GetFrameCommandContext();
             }
 
             for (int i = std::max(pass.scopes.size(), resources.scopeStack.size()) - 1; i >= 0; i--) {
@@ -329,7 +329,7 @@ namespace sp::vulkan {
 
             auto image = resources.GetRenderTarget(dep.id)->ImageView()->Image();
 
-            if (!cmd) cmd = device.GetCommandContext();
+            if (!cmd) cmd = device.GetFrameCommandContext();
             cmd->ImageBarrier(image,
                 image->LastLayout(),
                 dep.access.layout,
@@ -349,7 +349,7 @@ namespace sp::vulkan {
                 auto image = view->Image();
                 if (view->IsSwapchain()) continue; // barrier handled by RenderPass implicitly
 
-                if (!cmd) cmd = device.GetCommandContext();
+                if (!cmd) cmd = device.GetFrameCommandContext();
 
                 if (res.renderTargetDesc.usage & vk::ImageUsageFlagBits::eColorAttachment) {
                     if (image->LastLayout() == vk::ImageLayout::eColorAttachmentOptimal) continue;

--- a/src/graphics/graphics/vulkan/core/Screenshot.cc
+++ b/src/graphics/graphics/vulkan/core/Screenshot.cc
@@ -48,7 +48,7 @@ namespace sp::vulkan {
 
         auto outputImage = device.AllocateImage(outputDesc, VMA_MEMORY_USAGE_GPU_TO_CPU);
 
-        auto transferCmd = device.GetCommandContext(CommandContextType::General);
+        auto transferCmd = device.GetFencedCommandContext(CommandContextType::General);
         transferCmd->ImageBarrier(outputImage,
             vk::ImageLayout::eUndefined,
             vk::ImageLayout::eTransferDstOptimal,
@@ -100,10 +100,10 @@ namespace sp::vulkan {
                 vk::AccessFlagBits::eMemoryRead);
         }
 
-        auto fence = device->createFenceUnique({});
-        device.Submit(transferCmd, {}, {}, {}, *fence);
+        auto fence = transferCmd->Fence();
+        device.Submit(transferCmd, {}, {}, {});
 
-        AssertVKSuccess(device->waitForFences({*fence}, true, 1e10), "waiting for fence");
+        AssertVKSuccess(device->waitForFences({fence}, true, 1e10), "waiting for fence");
 
         vk::ImageSubresource subResource = {vk::ImageAspectFlagBits::eColor, 0, 0};
         auto subResourceLayout = device->getImageSubresourceLayout(*outputImage, subResource);


### PR DESCRIPTION
Fixes races with long running GPU commands overlapping frame boundaries.

Also:
- allocate 1GiB of device memory at a time (instead of the 256GiB default) to reduce stalls
- properly reset fence scoped command contexts
- move Tracy GPU collection to the start of frame to reduce issues with its query pool (but it can stall the frame for longer now)