### PR TITLE
Move some debug logs to tracing

### DIFF
--- a/src/core/assets/AssetManager.cc
+++ b/src/core/assets/AssetManager.cc
@@ -9,7 +9,7 @@ extern "C" {
 #include "assets/Image.hh"
 #include "assets/Model.hh"
 #include "assets/Script.hh"
-#include "core/Logging.hh"
+#include "core/Tracing.hh"
 #include "ecs/Components.hh"
 #include "ecs/Ecs.hh"
 #include "ecs/EcsImpl.hh"
@@ -185,7 +185,8 @@ namespace sp {
             {
                 std::lock_guard lock(taskMutex);
                 runningTasks.emplace_back(std::async(std::launch::async, [this, path, type, asset] {
-                    Debugf("Loading asset: %s", path);
+                    ZoneScopedN("LoadAsset");
+                    ZoneStr(path);
                     std::ifstream in;
                     size_t size;
 

--- a/src/core/assets/Model.cc
+++ b/src/core/assets/Model.cc
@@ -3,6 +3,7 @@
 #include "assets/Asset.hh"
 #include "assets/AssetManager.hh"
 #include "core/Logging.hh"
+#include "core/Tracing.hh"
 
 #include <filesystem>
 #include <fstream>
@@ -67,7 +68,8 @@ namespace sp {
     }
 
     Model::~Model() {
-        Debugf("Destroying model %s", name);
+        ZoneScoped;
+        ZoneStr(name);
     }
 
     bool Model::HasBuffer(size_t index) const {
@@ -114,14 +116,15 @@ namespace sp {
     }
 
     void Model::PopulateFromAsset(std::shared_ptr<const Asset> asset, const tinygltf::FsCallbacks *fsCallbacks) {
+        ZoneScoped;
+        ZonePrintf("%s from %s", name, asset->path);
+
         Assert(asset, "Loading Model from null asset");
         this->asset = asset;
         asset->WaitUntilValid();
 
         std::filesystem::path fsPath(asset->path);
         std::string baseDir = fsPath.remove_filename().string();
-
-        Debugf("Loading model %s from %s", name, asset->path);
 
         auto gltfModel = std::make_shared<tinygltf::Model>();
         std::string err;

--- a/src/core/core/Tracing.hh
+++ b/src/core/core/Tracing.hh
@@ -1,5 +1,47 @@
 #pragma once
 
+#include "Logging.hh"
+
 #include <tracy/Tracy.hpp>
 
-#define CPUZone ZoneScoped
+#define ZoneStr(str) ZoneStrV(___tracy_scoped_zone, str)
+#define ZoneStrV(varname, str) sp::tracing::TracingZoneStr(varname, str)
+#define ZonePrintf(fmt, ...) ZonePrintfV(___tracy_scoped_zone, fmt, __VA_ARGS__)
+#define ZonePrintfV(varname, fmt, ...) sp::tracing::TracingZonePrintf(varname, fmt, __VA_ARGS__)
+
+#define TracePrintf(fmt, ...) sp::tracing::TracingPrintf(fmt, __VA_ARGS__)
+
+namespace sp::tracing {
+    inline static void TracingZoneStr(tracy::ScopedZone &zone, const string_view &str) {
+        zone.Text(str.data(), str.size());
+    }
+
+    inline static void TracingZoneStr(tracy::ScopedZone &zone, const std::string &str) {
+        zone.Text(str.data(), str.size());
+    }
+
+    inline static void TracingZoneStr(tracy::ScopedZone &zone, const char *str) {
+        zone.Text(str, strlen(str));
+    }
+
+    template<typename... T>
+    inline static std::pair<std::unique_ptr<char[]>, int> tracingSprintf(const char *fmt, T &&...t) {
+        int size = std::snprintf(nullptr, 0, fmt, std::forward<T>(t)...);
+        std::unique_ptr<char[]> buf(new char[size + 1]);
+        std::snprintf(buf.get(), size + 1, fmt, std::forward<T>(t)...);
+        return std::make_pair(std::move(buf), size);
+    }
+
+    template<typename... T>
+    inline static void TracingZonePrintf(tracy::ScopedZone &zone, const char *fmt, T &&...t) {
+        auto buf = tracingSprintf(fmt, logging::convert(std::forward<T>(t))...);
+        zone.Text(buf.first.get(), buf.second);
+    }
+
+    template<typename... T>
+    inline static void TracingPrintf(const char *fmt, T &&...t) {
+        auto buf = tracingSprintf(fmt, logging::convert(std::forward<T>(t))...);
+        TracyMessage(buf.first.get(), buf.second);
+    }
+
+} // namespace sp::tracing

--- a/src/core/game/Scene.cc
+++ b/src/core/game/Scene.cc
@@ -1,6 +1,6 @@
 #include "Scene.hh"
 
-#include "core/Logging.hh"
+#include "core/Tracing.hh"
 #include "game/SceneManager.hh"
 
 namespace sp {
@@ -52,7 +52,8 @@ namespace sp {
 
     void Scene::ApplyScene(ecs::Lock<ecs::ReadAll, ecs::Write<ecs::SceneInfo>> staging,
         ecs::Lock<ecs::AddRemove> live) {
-        Logf("Applying scene: %s", name);
+        ZoneScoped;
+        ZoneStr(name);
         for (auto e : staging.EntitiesWith<ecs::SceneInfo>()) {
             auto &sceneInfo = e.Get<ecs::SceneInfo>(staging);
             if (sceneInfo.scene.lock().get() != this) continue;
@@ -66,7 +67,8 @@ namespace sp {
                     sceneInfo.liveId = ecs::EntityWith<ecs::Name>(live, entityName);
                     if (sceneInfo.liveId) {
                         // Entity overlaps with another scene
-                        Logf("Merging entity: %s", entityName);
+                        ZoneScopedN("MergeEntity");
+                        ZoneStr(entityName);
                         Assert(sceneInfo.liveId.Has<ecs::SceneInfo>(live), "Expected liveId to have SceneInfo");
                         auto &liveSceneInfo = sceneInfo.liveId.Get<ecs::SceneInfo>(live);
                         liveSceneInfo.InsertWithPriority(staging, sceneInfo);
@@ -90,7 +92,8 @@ namespace sp {
     }
 
     void Scene::RemoveScene(ecs::Lock<ecs::AddRemove> staging, ecs::Lock<ecs::AddRemove> live) {
-        Logf("Removing scene: %s", name);
+        ZoneScoped;
+        ZoneStr(name);
         for (auto &e : staging.EntitiesWith<ecs::SceneInfo>()) {
             if (!e.Has<ecs::SceneInfo>(staging)) continue;
             auto &sceneInfo = e.Get<ecs::SceneInfo>(staging);

--- a/src/graphics/graphics/vulkan/Renderer.cc
+++ b/src/graphics/graphics/vulkan/Renderer.cc
@@ -1178,8 +1178,6 @@ namespace sp::vulkan {
         ZoneScoped;
         activeModels.Tick(std::chrono::milliseconds(33)); // Minimum 30 fps tick rate
 
-        chrono_clock::duration totalLoadTime = {};
-
         for (int i = (int)modelsToLoad.size() - 1; i >= 0; i--) {
             auto &model = modelsToLoad[i];
             if (activeModels.Contains(model->name)) {
@@ -1187,17 +1185,9 @@ namespace sp::vulkan {
                 continue;
             }
 
-            auto start = chrono_clock::now();
             auto vulkanModel = make_shared<Model>(model, scene, device);
             activeModels.Register(model->name, vulkanModel);
-
-            auto loadTime = chrono_clock::now() - start;
-            auto usLoadTime = std::chrono::duration_cast<std::chrono::microseconds>(loadTime).count();
-            Debugf("Loaded vulkan model %s in %llu.%llu ms", model->name, usLoadTime / 1000, usLoadTime % 1000);
-
             modelsToLoad.pop_back();
-            totalLoadTime += loadTime;
-            if (totalLoadTime > std::chrono::milliseconds(10)) break;
         }
 
         scene.FlushTextureDescriptors();

--- a/src/graphics/graphics/vulkan/core/DeviceContext.cc
+++ b/src/graphics/graphics/vulkan/core/DeviceContext.cc
@@ -56,6 +56,7 @@ namespace sp::vulkan {
         default:
             break;
         }
+        TracePrintf("VK %s %s", typeStr, pCallbackData->pMessage);
         return VK_FALSE;
     }
 
@@ -1337,6 +1338,8 @@ namespace sp::vulkan {
     }
 
     shared_ptr<Shader> DeviceContext::CreateShader(const string &name, Hash64 compareHash) {
+        ZoneScoped;
+        ZoneStr(name);
         auto asset = GAssets.Load("shaders/vulkan/bin/" + name + ".spv", AssetType::Bundled, compareHash != Hash64());
         Assertf(asset, "could not load shader: %s", name);
         asset->WaitUntilValid();
@@ -1355,7 +1358,6 @@ namespace sp::vulkan {
             Abortf("could not parse shader: %s error: %d", name, reflection.GetResult());
         }
 
-        Debugf("loaded shader module: %s", name);
         return make_shared<Shader>(name, std::move(shaderModule), std::move(reflection), newHash);
     }
 

--- a/src/graphics/graphics/vulkan/core/Memory.cc
+++ b/src/graphics/graphics/vulkan/core/Memory.cc
@@ -54,6 +54,7 @@ namespace sp::vulkan {
     Buffer::Buffer(vk::BufferCreateInfo bufferInfo, VmaAllocationCreateInfo allocInfo, VmaAllocator allocator)
         : UniqueMemory(allocator), bufferInfo(bufferInfo) {
         ZoneScoped;
+        ZoneValue(bufferInfo.size);
 
         if (bufferInfo.size == 0) return; // allow creating empty buffers for convenience
 

--- a/src/graphics/graphics/vulkan/core/Model.cc
+++ b/src/graphics/graphics/vulkan/core/Model.cc
@@ -2,6 +2,7 @@
 
 #include "assets/Model.hh"
 #include "core/Logging.hh"
+#include "core/Tracing.hh"
 #include "ecs/EcsImpl.hh"
 #include "graphics/vulkan/core/CommandContext.hh"
 #include "graphics/vulkan/core/DeviceContext.hh"
@@ -13,6 +14,7 @@ namespace sp::vulkan {
     Model::Model(shared_ptr<const sp::Model> model, GPUSceneContext &scene, DeviceContext &device)
         : modelName(model->name), scene(scene), asset(model) {
         ZoneScoped;
+        ZoneStr(modelName);
         // TODO: cache the output somewhere. Keeping the conversion code in
         // the engine will be useful for any dynamic loading in the future,
         // but we don't want to do it every time a model is loaded.
@@ -153,7 +155,8 @@ namespace sp::vulkan {
     }
 
     Model::~Model() {
-        Debugf("Destroying vulkan::Model %s", modelName);
+        ZoneScoped;
+        ZoneStr(modelName);
 
         for (auto it : textures) {
             scene.ReleaseTexture(it.second);

--- a/src/graphics/graphics/vulkan/core/RenderTarget.cc
+++ b/src/graphics/graphics/vulkan/core/RenderTarget.cc
@@ -1,12 +1,14 @@
 #include "RenderTarget.hh"
 
-#include "core/Logging.hh"
+#include "core/Tracing.hh"
 #include "graphics/vulkan/core/DeviceContext.hh"
 
 namespace sp::vulkan {
     RenderTarget::~RenderTarget() {
         if (poolIndex != ~0u) {
-            Debugf("Destroying render target %d, size=%dx%d", poolIndex, desc.extent.width, desc.extent.height);
+            ZoneScoped;
+            ZoneValue(poolIndex);
+            ZonePrintf("size=%dx%d", desc.extent.width, desc.extent.height);
         }
     }
 
@@ -32,7 +34,9 @@ namespace sp::vulkan {
             }
         }
 
-        Debugf("Creating render target %d, size=%dx%d", pool.size(), desc.extent.width, desc.extent.height);
+        ZoneScopedN("CreateRenderTarget");
+        ZoneValue(pool.size());
+        ZonePrintf("size=%dx%d", desc.extent.width, desc.extent.height);
 
         ImageCreateInfo imageInfo;
         imageInfo.imageType = vk::ImageType::e2D;


### PR DESCRIPTION
- adds ZonePrintf, which uses our logging printf conversion to attach arbitrary data to a trace zone
- adds ZoneStr, which attaches a std::string, string_view, or const char * to a trace zone
- adds TracePrintf, which generally can replace Debugf
  - in Tracy, you can see these messages on the main timeline
  - by clicking a message in the timeline, or clicking "Messages" in the top menu, you can see a list of messages with timestamps and thread name, filterable by thread