### PR TITLE
Allow setting allocation preferred/required flags, use host memory for texture staging

### DIFF
--- a/src/core/core/Tracing.hh
+++ b/src/core/core/Tracing.hh
@@ -9,7 +9,7 @@
 #define ZonePrintf(...) ZonePrintfV(___tracy_scoped_zone, __VA_ARGS__)
 #define ZonePrintfV(varname, ...) sp::tracing::TracingZonePrintf(varname, __VA_ARGS__)
 
-#define Tracef(fmt, ...) sp::tracing::TracingPrintf(fmt, __VA_ARGS__)
+#define Tracef(...) sp::tracing::TracingPrintf(__VA_ARGS__)
 
 namespace sp::tracing {
     inline static void TracingZoneStr(tracy::ScopedZone &zone, const string_view &str) {

--- a/src/graphics/graphics/vulkan/core/DeviceContext.cc
+++ b/src/graphics/graphics/vulkan/core/DeviceContext.cc
@@ -823,6 +823,10 @@ namespace sp::vulkan {
         return make_shared<Buffer>(bufferInfo, allocInfo, allocator.get());
     }
 
+    BufferPtr DeviceContext::AllocateBuffer(vk::BufferCreateInfo bufferInfo, VmaAllocationCreateInfo allocInfo) {
+        return make_shared<Buffer>(bufferInfo, allocInfo, allocator.get());
+    }
+
     BufferPtr DeviceContext::GetFramePooledBuffer(BufferType type, vk::DeviceSize size) {
         auto &pool = Frame().bufferPools[type];
         for (auto &buf : pool) {
@@ -868,6 +872,26 @@ namespace sp::vulkan {
         auto buffer = AllocateBuffer(size, usage, residency);
         pool.emplace_back(PooledBuffer{buffer, size, true});
         return buffer;
+    }
+
+    std::future<BufferPtr> DeviceContext::CreateBuffer(const InitialData &data,
+        vk::BufferCreateInfo bufferInfo,
+        VmaAllocationCreateInfo allocInfo) {
+        return allocatorQueue.Dispatch<BufferPtr>([=, this]() {
+            auto buf = AllocateBuffer(bufferInfo, allocInfo);
+            buf->CopyFrom(data.data, data.dataSize);
+            return buf;
+        });
+    }
+
+    std::future<BufferPtr> DeviceContext::CreateBuffer(const InitialData &data,
+        vk::BufferUsageFlags usage,
+        VmaMemoryUsage residency) {
+        return allocatorQueue.Dispatch<BufferPtr>([=, this]() {
+            auto buf = AllocateBuffer(data.dataSize, usage, residency);
+            buf->CopyFrom(data.data, data.dataSize);
+            return buf;
+        });
     }
 
     ImagePtr DeviceContext::AllocateImage(vk::ImageCreateInfo info,
@@ -921,7 +945,13 @@ namespace sp::vulkan {
         });
         if (!hasSrcData) return futImage;
 
-        auto futStagingBuf = CreateBuffer(data, vk::BufferUsageFlagBits::eTransferSrc, VMA_MEMORY_USAGE_CPU_TO_GPU);
+        vk::BufferCreateInfo bufferInfo;
+        bufferInfo.size = data.dataSize;
+        bufferInfo.usage = vk::BufferUsageFlagBits::eTransferSrc;
+        VmaAllocationCreateInfo allocInfo = {};
+        allocInfo.usage = VMA_MEMORY_USAGE_CPU_TO_GPU;
+        allocInfo.preferredFlags = VK_MEMORY_PROPERTY_HOST_COHERENT_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
+        auto futStagingBuf = CreateBuffer(data, bufferInfo, allocInfo);
 
         return frameEndQueue.Dispatch<ImagePtr>(std::move(futImage),
             std::move(futStagingBuf),

--- a/src/graphics/graphics/vulkan/core/DeviceContext.hh
+++ b/src/graphics/graphics/vulkan/core/DeviceContext.hh
@@ -97,6 +97,7 @@ namespace sp::vulkan {
             vk::Fence fence = {});
 
         BufferPtr AllocateBuffer(vk::DeviceSize size, vk::BufferUsageFlags usage, VmaMemoryUsage residency);
+        BufferPtr AllocateBuffer(vk::BufferCreateInfo bufferInfo, VmaAllocationCreateInfo allocInfo);
 
         template<typename T>
         BufferPtr CreateBuffer(const T *srcData,
@@ -109,14 +110,12 @@ namespace sp::vulkan {
         }
 
         std::future<BufferPtr> CreateBuffer(const InitialData &data,
+            vk::BufferCreateInfo bufferInfo,
+            VmaAllocationCreateInfo allocInfo);
+
+        std::future<BufferPtr> CreateBuffer(const InitialData &data,
             vk::BufferUsageFlags usage,
-            VmaMemoryUsage residency) {
-            return allocatorQueue.Dispatch<BufferPtr>([=, this]() {
-                auto buf = AllocateBuffer(data.dataSize, usage, residency);
-                buf->CopyFrom(data.data, data.dataSize);
-                return buf;
-            });
-        }
+            VmaMemoryUsage residency);
 
         BufferPtr GetFramePooledBuffer(BufferType type, vk::DeviceSize size);
 

--- a/src/graphics/graphics/vulkan/core/Memory.cc
+++ b/src/graphics/graphics/vulkan/core/Memory.cc
@@ -1,10 +1,6 @@
-#include "core/Tracing.hh"
-#define VMA_DEBUG_LOG(...)            \
-    ZoneNamed(__tracy__LINE__, true); \
-    ZonePrintfV(__tracy__LINE__, __VA_ARGS__)
-
 #define VMA_IMPLEMENTATION
 #include "Memory.hh"
+
 #include "core/Common.hh"
 
 namespace sp::vulkan {

--- a/src/graphics/graphics/vulkan/core/Memory.hh
+++ b/src/graphics/graphics/vulkan/core/Memory.hh
@@ -22,6 +22,8 @@
     #pragma warning(disable : 4127 4189 4324)
 #endif
 
+#define VMA_DEBUG_LOG(...) Tracef(__VA_ARGS__)
+
 #include <vk_mem_alloc.h>
 
 #ifdef __GNUC__


### PR DESCRIPTION
Fixes hitching that occurred when trying to allocate a lot of memory from a DMA heap on my machine. This makes the image staging allocations prefer host cached + host coherent memory.