### PR TITLE
Present empty image when there's no window entity

### DIFF
--- a/src/graphics/graphics/vulkan/core/RenderGraph.hh
+++ b/src/graphics/graphics/vulkan/core/RenderGraph.hh
@@ -16,6 +16,8 @@ namespace sp::vulkan {
 
     class PerfTimer;
 
+    const RenderGraphResourceID RenderGraphInvalidResource = ~0u;
+
     struct RenderGraphResource {
         enum class Type {
             Undefined,
@@ -31,7 +33,7 @@ namespace sp::vulkan {
             return type != Type::Undefined;
         }
 
-        RenderGraphResourceID id = ~0u;
+        RenderGraphResourceID id = RenderGraphInvalidResource;
         Type type = Type::Undefined;
         union {
             RenderTargetDesc renderTargetDesc;
@@ -62,7 +64,7 @@ namespace sp::vulkan {
     private:
         friend class RenderGraph;
         friend class RenderGraphPassBuilder;
-        RenderGraphResourceID resourceID = ~0u;
+        RenderGraphResourceID resourceID = RenderGraphInvalidResource;
     };
 
     class RenderGraphResources {
@@ -89,7 +91,7 @@ namespace sp::vulkan {
             return GetResource(lastOutputID);
         }
 
-        static const RenderGraphResourceID npos = ~0u;
+        static const RenderGraphResourceID npos = RenderGraphInvalidResource;
 
     private:
         friend class RenderGraph;


### PR DESCRIPTION
The window view is now loaded asynchronously and thus the renderer can start before it exists. This renders a blank frame (and the debug gui even works) if the default window view target (i.e. FlatView) doesn't exist.

This could be changed to draw an image if we want at some point.