### PR TITLE
Much better system for GPU resource access management

### DIFF
--- a/src/graphics/graphics/vulkan/Renderer.cc
+++ b/src/graphics/graphics/vulkan/Renderer.cc
@@ -143,7 +143,7 @@ namespace sp::vulkan {
                     } else {
                         sourceID = renderer::VisualizeBuffer(graph, res.id, layer);
                     }
-                    builder.TextureRead(sourceID);
+                    builder.Read(sourceID, rg::Access::FragmentShaderSampleImage);
                 } else {
                     loadOp = LoadOp::Clear;
                 }
@@ -192,17 +192,11 @@ namespace sp::vulkan {
                 desc.format = vk::Format::eD24UnormS8Uint;
                 builder.OutputDepthAttachment("GBufferDepthStencil", desc, {LoadOp::Clear, StoreOp::Store});
 
-                builder.UniformCreate("ViewState", sizeof(GPUViewState) * 2);
+                builder.CreateUniform("ViewState", sizeof(GPUViewState) * 2);
 
-                builder.BufferAccess("WarpedVertexBuffer",
-                    rg::PipelineStage::eVertexInput,
-                    rg::Access::eVertexAttributeRead,
-                    rg::BufferUsage::eVertexBuffer);
-                builder.BufferAccess(drawIDs.drawCommandsBuffer,
-                    rg::PipelineStage::eDrawIndirect,
-                    rg::Access::eIndirectCommandRead,
-                    rg::BufferUsage::eIndirectBuffer);
-                builder.StorageRead(drawIDs.drawParamsBuffer, rg::PipelineStage::eVertexShader);
+                builder.Read("WarpedVertexBuffer", rg::Access::VertexBuffer);
+                builder.Read(drawIDs.drawCommandsBuffer, rg::Access::IndirectBuffer);
+                builder.Read(drawIDs.drawParamsBuffer, rg::Access::VertexShaderReadStorage);
             })
             .Execute([this, view, drawIDs](rg::Resources &resources, CommandContext &cmd) {
                 cmd.SetShaders("scene.vert", "generate_gbuffer.frag");
@@ -316,17 +310,11 @@ namespace sp::vulkan {
                 builder.OutputColorAttachment(2, "GBuffer2", desc, {LoadOp::Clear, StoreOp::Store});
                 builder.SetDepthAttachment("GBufferDepthStencil", {LoadOp::Load, StoreOp::Store});
 
-                builder.UniformCreate("ViewState", sizeof(GPUViewState) * 2);
+                builder.CreateUniform("ViewState", sizeof(GPUViewState) * 2);
 
-                builder.BufferAccess("WarpedVertexBuffer",
-                    rg::PipelineStage::eVertexInput,
-                    rg::Access::eVertexAttributeRead,
-                    rg::BufferUsage::eVertexBuffer);
-                builder.BufferAccess(drawIDs.drawCommandsBuffer,
-                    rg::PipelineStage::eDrawIndirect,
-                    rg::Access::eIndirectCommandRead,
-                    rg::BufferUsage::eIndirectBuffer);
-                builder.StorageRead(drawIDs.drawParamsBuffer, rg::PipelineStage::eVertexShader);
+                builder.Read("WarpedVertexBuffer", rg::Access::VertexBuffer);
+                builder.Read(drawIDs.drawCommandsBuffer, rg::Access::IndirectBuffer);
+                builder.Read(drawIDs.drawParamsBuffer, rg::Access::VertexShaderReadStorage);
             })
             .Execute([this, viewsByEye, drawIDs](rg::Resources &resources, CommandContext &cmd) {
                 cmd.SetShaders("scene.vert", "generate_gbuffer.frag");
@@ -385,7 +373,7 @@ namespace sp::vulkan {
                     sourceID = renderer::VisualizeBuffer(graph, res.id);
                 }
 
-                builder.TransferRead(sourceID);
+                builder.Read(sourceID, rg::Access::TransferRead);
                 builder.RequirePass();
             })
             .Execute([this, sourceID](rg::Resources &resources, DeviceContext &device) {
@@ -480,8 +468,8 @@ namespace sp::vulkan {
 
         graph.AddPass("MenuOverlay")
             .Build([&](rg::PassBuilder &builder) {
-                builder.TextureRead(builder.LastOutputID());
-                builder.TextureRead(menuID);
+                builder.Read(builder.LastOutputID(), rg::Access::FragmentShaderSampleImage);
+                builder.Read(menuID, rg::Access::FragmentShaderSampleImage);
 
                 auto desc = builder.GetResource(inputID).DeriveRenderTarget();
                 builder.OutputColorAttachment(0, "Menu", desc, {LoadOp::DontCare, StoreOp::Store});

--- a/src/graphics/graphics/vulkan/core/RenderTarget.cc
+++ b/src/graphics/graphics/vulkan/core/RenderTarget.cc
@@ -37,7 +37,7 @@ namespace sp::vulkan {
         }
 
         auto createDesc = desc;
-        ZoneScopedN("RenderTargetCreate");
+        ZoneScopedN("CreateRenderTarget");
         ZoneValue(pool.size());
         ZonePrintf("size=%dx%dx%d", createDesc.extent.width, desc.extent.height, desc.extent.depth);
 

--- a/src/graphics/graphics/vulkan/render_graph/Access.hh
+++ b/src/graphics/graphics/vulkan/render_graph/Access.hh
@@ -1,0 +1,242 @@
+#pragma once
+
+#include "graphics/vulkan/core/Common.hh"
+
+namespace sp::vulkan::render_graph {
+    enum class Access : uint8_t {
+        None,
+
+        // Reads
+        IndirectBuffer,
+        IndexBuffer,
+        VertexBuffer,
+        VertexShaderSampleImage,
+        VertexShaderReadUniform,
+        VertexShaderReadStorage,
+        FragmentShaderSampleImage,
+        FragmentShaderReadUniform,
+        FragmentShaderReadStorage,
+        FragmentShaderReadColorInputAttachment,
+        FragmentShaderReadDepthInputStencilAttachment,
+        ColorAttachmentRead,
+        DepthStencilAttachmentRead,
+        ComputeShaderSampleImage,
+        ComputeShaderReadUniform,
+        ComputeShaderReadStorage,
+        AnyShaderSampleImage,
+        AnyShaderReadUniform,
+        AnyShaderReadStorage,
+        TransferRead,
+        HostRead,
+
+        AccessTypesEndOfReads,
+
+        // Writes
+        VertexShaderWrite,
+        FragmentShaderWrite,
+        ColorAttachmentWrite,
+        ColorAttachmentReadWrite,
+        DepthStencilAttachmentWrite,
+        ComputeShaderWrite,
+        AnyShaderWrite,
+        TransferWrite,
+        HostPreinitialized,
+        HostWrite,
+
+        AccessTypesCount,
+    };
+
+    inline bool AccessIsWrite(Access access) {
+        return access > Access::AccessTypesEndOfReads && access < Access::AccessTypesCount;
+    }
+
+    struct AccessInfo {
+        vk::PipelineStageFlags stageMask;
+        vk::AccessFlags accessMask;
+        vk::BufferUsageFlags bufferUsageMask;
+        vk::ImageUsageFlags imageUsageMask;
+        vk::ImageLayout imageLayout;
+    };
+
+    const AccessInfo AccessMap[(size_t)Access::AccessTypesCount] = {
+        // None
+        {{}, {}, {}, {}, vk::ImageLayout::eUndefined},
+        // IndirectBuffer
+        {vk::PipelineStageFlagBits::eDrawIndirect,
+            vk::AccessFlagBits::eIndirectCommandRead,
+            vk::BufferUsageFlagBits::eIndirectBuffer,
+            {},
+            vk::ImageLayout::eUndefined},
+        // IndexBuffer
+        {vk::PipelineStageFlagBits::eVertexInput,
+            vk::AccessFlagBits::eIndexRead,
+            vk::BufferUsageFlagBits::eIndexBuffer,
+            {},
+            vk::ImageLayout::eUndefined},
+        // VertexBuffer
+        {vk::PipelineStageFlagBits::eVertexInput,
+            vk::AccessFlagBits::eVertexAttributeRead,
+            vk::BufferUsageFlagBits::eVertexBuffer,
+            {},
+            vk::ImageLayout::eUndefined},
+        // VertexShaderSampleImage
+        {vk::PipelineStageFlagBits::eVertexShader,
+            vk::AccessFlagBits::eShaderRead,
+            {},
+            vk::ImageUsageFlagBits::eSampled,
+            vk::ImageLayout::eShaderReadOnlyOptimal},
+        // VertexShaderReadUniform
+        {vk::PipelineStageFlagBits::eVertexShader,
+            vk::AccessFlagBits::eUniformRead,
+            vk::BufferUsageFlagBits::eUniformBuffer,
+            {},
+            vk::ImageLayout::eUndefined},
+        // VertexShaderReadStorage
+        {vk::PipelineStageFlagBits::eVertexShader,
+            vk::AccessFlagBits::eShaderRead,
+            vk::BufferUsageFlagBits::eStorageBuffer,
+            vk::ImageUsageFlagBits::eStorage,
+            vk::ImageLayout::eGeneral},
+        // FragmentShaderSampleImage
+        {vk::PipelineStageFlagBits::eFragmentShader,
+            vk::AccessFlagBits::eShaderRead,
+            {},
+            vk::ImageUsageFlagBits::eSampled,
+            vk::ImageLayout::eShaderReadOnlyOptimal},
+        // FragmentShaderReadUniform,
+        {vk::PipelineStageFlagBits::eFragmentShader,
+            vk::AccessFlagBits::eUniformRead,
+            vk::BufferUsageFlagBits::eUniformBuffer,
+            {},
+            vk::ImageLayout::eUndefined},
+        // FragmentShaderReadStorage
+        {vk::PipelineStageFlagBits::eFragmentShader,
+            vk::AccessFlagBits::eShaderRead,
+            vk::BufferUsageFlagBits::eStorageBuffer,
+            vk::ImageUsageFlagBits::eStorage,
+            vk::ImageLayout::eGeneral},
+        // FragmentShaderReadColorInputAttachment
+        {vk::PipelineStageFlagBits::eFragmentShader,
+            vk::AccessFlagBits::eInputAttachmentRead,
+            {},
+            vk::ImageUsageFlagBits::eInputAttachment,
+            vk::ImageLayout::eShaderReadOnlyOptimal},
+        // FragmentShaderReadDepthStencilInputAttachment
+        {vk::PipelineStageFlagBits::eFragmentShader,
+            vk::AccessFlagBits::eInputAttachmentRead,
+            {},
+            vk::ImageUsageFlagBits::eInputAttachment,
+            vk::ImageLayout::eDepthStencilReadOnlyOptimal},
+        // ColorAttachmentRead
+        {vk::PipelineStageFlagBits::eColorAttachmentOutput,
+            vk::AccessFlagBits::eColorAttachmentRead,
+            {},
+            vk::ImageUsageFlagBits::eColorAttachment,
+            vk::ImageLayout::eColorAttachmentOptimal},
+        // DepthStencilAttachmentRead
+        {vk::PipelineStageFlagBits::eEarlyFragmentTests | vk::PipelineStageFlagBits::eLateFragmentTests,
+            vk::AccessFlagBits::eDepthStencilAttachmentRead,
+            {},
+            vk::ImageUsageFlagBits::eDepthStencilAttachment,
+            vk::ImageLayout::eDepthStencilReadOnlyOptimal},
+        // ComputeShaderSampleImage
+        {vk::PipelineStageFlagBits::eComputeShader,
+            vk::AccessFlagBits::eShaderRead,
+            {},
+            vk::ImageUsageFlagBits::eSampled,
+            vk::ImageLayout::eShaderReadOnlyOptimal},
+        // ComputeShaderReadUniform
+        {vk::PipelineStageFlagBits::eComputeShader,
+            vk::AccessFlagBits::eUniformRead,
+            vk::BufferUsageFlagBits::eUniformBuffer,
+            {},
+            vk::ImageLayout::eUndefined},
+        // ComputeShaderReadStorage
+        {vk::PipelineStageFlagBits::eComputeShader,
+            vk::AccessFlagBits::eShaderRead,
+            vk::BufferUsageFlagBits::eStorageBuffer,
+            vk::ImageUsageFlagBits::eStorage,
+            vk::ImageLayout::eGeneral},
+        // AnyShaderSampleImage
+        {vk::PipelineStageFlagBits::eAllCommands,
+            vk::AccessFlagBits::eShaderRead,
+            {},
+            vk::ImageUsageFlagBits::eSampled,
+            vk::ImageLayout::eShaderReadOnlyOptimal},
+        // AnyShaderReadUniform
+        {vk::PipelineStageFlagBits::eAllCommands,
+            vk::AccessFlagBits::eUniformRead,
+            vk::BufferUsageFlagBits::eUniformBuffer,
+            {},
+            vk::ImageLayout::eUndefined},
+        // AnyShaderReadStorage
+        {vk::PipelineStageFlagBits::eAllCommands,
+            vk::AccessFlagBits::eShaderRead,
+            vk::BufferUsageFlagBits::eStorageBuffer,
+            vk::ImageUsageFlagBits::eStorage,
+            vk::ImageLayout::eGeneral},
+        // TransferRead
+        {vk::PipelineStageFlagBits::eTransfer,
+            vk::AccessFlagBits::eTransferRead,
+            vk::BufferUsageFlagBits::eTransferSrc,
+            vk::ImageUsageFlagBits::eTransferSrc,
+            vk::ImageLayout::eTransferSrcOptimal},
+        // HostRead
+        {vk::PipelineStageFlagBits::eHost, vk::AccessFlagBits::eHostRead, {}, {}, vk::ImageLayout::eGeneral},
+        // EndOfReads, not a valid index
+        {{}, {}, {}, {}, vk::ImageLayout::eUndefined},
+        // VertexShaderWrite
+        {vk::PipelineStageFlagBits::eVertexShader,
+            vk::AccessFlagBits::eShaderWrite,
+            vk::BufferUsageFlagBits::eStorageBuffer,
+            vk::ImageUsageFlagBits::eStorage,
+            vk::ImageLayout::eGeneral},
+        // FragmentShaderWrite
+        {vk::PipelineStageFlagBits::eFragmentShader,
+            vk::AccessFlagBits::eShaderWrite,
+            vk::BufferUsageFlagBits::eStorageBuffer,
+            vk::ImageUsageFlagBits::eStorage,
+            vk::ImageLayout::eGeneral},
+        // ColorAttachmentWrite,
+        {vk::PipelineStageFlagBits::eColorAttachmentOutput,
+            vk::AccessFlagBits::eColorAttachmentWrite,
+            {},
+            vk::ImageUsageFlagBits::eColorAttachment,
+            vk::ImageLayout::eColorAttachmentOptimal},
+        // ColorAttachmentReadWrite
+        {vk::PipelineStageFlagBits::eColorAttachmentOutput,
+            vk::AccessFlagBits::eColorAttachmentWrite,
+            {},
+            vk::ImageUsageFlagBits::eColorAttachment,
+            vk::ImageLayout::eColorAttachmentOptimal},
+        // DepthStencilAttachmentWrite
+        {vk::PipelineStageFlagBits::eEarlyFragmentTests | vk::PipelineStageFlagBits::eLateFragmentTests,
+            vk::AccessFlagBits::eDepthStencilAttachmentWrite,
+            {},
+            vk::ImageUsageFlagBits::eDepthStencilAttachment,
+            vk::ImageLayout::eDepthStencilAttachmentOptimal},
+        // ComputeShaderWrite
+        {vk::PipelineStageFlagBits::eComputeShader,
+            vk::AccessFlagBits::eShaderWrite,
+            vk::BufferUsageFlagBits::eStorageBuffer,
+            vk::ImageUsageFlagBits::eStorage,
+            vk::ImageLayout::eGeneral},
+        // AnyShaderWrite
+        {vk::PipelineStageFlagBits::eAllCommands,
+            vk::AccessFlagBits::eShaderWrite,
+            vk::BufferUsageFlagBits::eStorageBuffer,
+            vk::ImageUsageFlagBits::eStorage,
+            vk::ImageLayout::eGeneral},
+        // TransferWrite
+        {vk::PipelineStageFlagBits::eTransfer,
+            vk::AccessFlagBits::eTransferWrite,
+            vk::BufferUsageFlagBits::eTransferDst,
+            vk::ImageUsageFlagBits::eTransferDst,
+            vk::ImageLayout::eTransferDstOptimal},
+        // HostPreinitialized
+        {vk::PipelineStageFlagBits::eHost, vk::AccessFlagBits::eHostWrite, {}, {}, vk::ImageLayout::ePreinitialized},
+        // HostWrite
+        {vk::PipelineStageFlagBits::eHost, vk::AccessFlagBits::eHostWrite, {}, {}, vk::ImageLayout::eGeneral},
+    };
+
+} // namespace sp::vulkan::render_graph

--- a/src/graphics/graphics/vulkan/render_graph/Pass.hh
+++ b/src/graphics/graphics/vulkan/render_graph/Pass.hh
@@ -8,19 +8,19 @@
 #include <variant>
 
 namespace sp::vulkan::render_graph {
-    struct ResourceAccess {
-        vk::PipelineStageFlags stages = {};
-        vk::AccessFlags access = {};
-        vk::ImageLayout layout = vk::ImageLayout::eUndefined;
+    struct ResourceIDAccess {
+        ResourceID id;
+        Access access;
+        bool creates = false;
+
+        bool IsWrite() const {
+            return AccessIsWrite(access);
+        }
     };
 
-    struct ResourceDependency {
+    struct ResourceIDFutureAccess {
         ResourceID id;
-        ResourceAccess access;
-    };
-
-    struct FutureResourceID {
-        ResourceID id;
+        Access access;
         int framesFromNow;
     };
 
@@ -48,16 +48,17 @@ namespace sp::vulkan::render_graph {
     public:
         Pass(string_view name) : name(name) {}
 
-        void AddDependency(const ResourceAccess &access, const Resource &res) {
-            dependencies.push_back({res.id, access});
+        void AddCreate(ResourceID id, Access access) {
+            accesses.push_back({id, access, true});
         }
-
-        void AddOutput(ResourceID id) {
-            outputs.push_back(id);
+        void AddRead(ResourceID id, Access access) {
+            accesses.push_back({id, access, false});
         }
-
-        void AddFutureDependency(ResourceID id, int framesFromNow) {
-            futureDependencies.push_back({id, framesFromNow});
+        void AddWrite(ResourceID id, Access access) {
+            accesses.push_back({id, access, false});
+        }
+        void AddFutureRead(ResourceID id, Access access, int framesFromNow) {
+            futureReads.push_back({id, access, framesFromNow});
         }
 
         bool HasExecute() const {
@@ -80,9 +81,8 @@ namespace sp::vulkan::render_graph {
         friend class RenderGraph;
         friend class PassBuilder;
         string_view name;
-        InlineVector<ResourceDependency, 32> dependencies;
-        InlineVector<ResourceID, 16> outputs;
-        vector<FutureResourceID> futureDependencies;
+        InlineVector<ResourceIDAccess, 32> accesses;
+        vector<ResourceIDFutureAccess> futureReads;
         std::array<AttachmentInfo, MAX_COLOR_ATTACHMENTS + 1> attachments;
         bool active = false, required = false;
         uint8 primaryAttachmentIndex = 0;

--- a/src/graphics/graphics/vulkan/render_graph/PassBuilder.cc
+++ b/src/graphics/graphics/vulkan/render_graph/PassBuilder.cc
@@ -1,145 +1,51 @@
 #include "PassBuilder.hh"
 
 namespace sp::vulkan::render_graph {
-    const Resource &PassBuilder::TransferRead(string_view name) {
-        return TransferRead(GetID(name));
+    void PassBuilder::Read(ResourceID id, Access access) {
+        pass.AddRead(id, access);
     }
 
-    const Resource &PassBuilder::TransferRead(ResourceID id) {
+    ResourceID PassBuilder::Read(string_view name, Access access) {
+        auto id = GetID(name);
+        Read(id, access);
+        return id;
+    }
+
+    ResourceID PassBuilder::ReadPreviousFrame(string_view name, Access access, int framesAgo) {
+        auto thisFrameID = resources.GetID(name, false);
+        if (thisFrameID == InvalidResource) thisFrameID = resources.ReserveID(name);
+        pass.AddFutureRead(thisFrameID, access, framesAgo);
+
+        auto prevFrameID = resources.GetID(name, false, framesAgo);
+        if (prevFrameID != InvalidResource) pass.AddRead(prevFrameID, access);
+        return prevFrameID;
+    }
+
+    void PassBuilder::Write(ResourceID id, Access access) {
+        pass.AddWrite(id, access);
+    }
+
+    ResourceID PassBuilder::Write(string_view name, Access access) {
+        auto id = GetID(name);
+        Write(id, access);
+        return id;
+    }
+
+    const Resource &PassBuilder::ReadUniform(string_view name) {
+        return ReadUniform(GetID(name));
+    }
+
+    const Resource &PassBuilder::ReadUniform(ResourceID id) {
+        Read(id, Access::AnyShaderReadUniform);
         auto &resource = resources.GetResourceRef(id);
-        ResourceAccess access = {vk::PipelineStageFlagBits::eTransfer, vk::AccessFlagBits::eTransferRead};
-        if (resource.type == Resource::Type::RenderTarget) {
-            resource.renderTargetDesc.usage |= vk::ImageUsageFlagBits::eTransferSrc;
-            access.layout = vk::ImageLayout::eTransferSrcOptimal;
-        } else if (resource.type == Resource::Type::Buffer) {
-            resource.bufferDesc.usage |= vk::BufferUsageFlagBits::eTransferSrc;
-        }
-        pass.AddDependency(access, resource);
-        return resource;
-    }
-
-    const Resource &PassBuilder::TransferWrite(string_view name) {
-        return TransferWrite(GetID(name));
-    }
-
-    const Resource &PassBuilder::TransferWrite(ResourceID id) {
-        auto &resource = resources.GetResourceRef(id);
-        ResourceAccess access = {vk::PipelineStageFlagBits::eTransfer, vk::AccessFlagBits::eTransferWrite};
-        if (resource.type == Resource::Type::RenderTarget) {
-            resource.renderTargetDesc.usage |= vk::ImageUsageFlagBits::eTransferDst;
-            access.layout = vk::ImageLayout::eTransferDstOptimal;
-        } else if (resource.type == Resource::Type::Buffer) {
-            resource.bufferDesc.usage |= vk::BufferUsageFlagBits::eTransferDst;
-        }
-        pass.AddDependency(access, resource);
-        return resource;
-    }
-    const Resource &PassBuilder::UniformRead(string_view name, PipelineStageMask stages) {
-        return UniformRead(GetID(name), stages);
-    }
-
-    const Resource &PassBuilder::UniformRead(ResourceID id, PipelineStageMask stages) {
-        auto &resource = resources.GetResourceRef(id);
-        ResourceAccess access = {
-            stages,
-            vk::AccessFlagBits::eUniformRead,
-        };
-        resource.bufferDesc.usage |= vk::BufferUsageFlagBits::eUniformBuffer;
         resource.bufferDesc.residency = Residency::CPU_TO_GPU;
-        pass.AddDependency(access, resource);
         return resource;
     }
 
-    const Resource &PassBuilder::TextureRead(string_view name, PipelineStageMask stages) {
-        return TextureRead(GetID(name), stages);
-    }
-
-    const Resource &PassBuilder::TextureRead(ResourceID id, PipelineStageMask stages) {
-        auto &resource = resources.GetResourceRef(id);
-        resource.renderTargetDesc.usage |= vk::ImageUsageFlagBits::eSampled;
-
-        auto aspect = FormatToAspectFlags(resource.renderTargetDesc.format);
-        bool depth = !!(aspect & vk::ImageAspectFlagBits::eDepth);
-        bool stencil = !!(aspect & vk::ImageAspectFlagBits::eStencil);
-
-        auto layout = vk::ImageLayout::eShaderReadOnlyOptimal;
-        if (depth && stencil)
-            layout = vk::ImageLayout::eDepthStencilReadOnlyOptimal;
-        else if (depth)
-            layout = vk::ImageLayout::eDepthReadOnlyOptimal;
-        else if (stencil)
-            layout = vk::ImageLayout::eStencilReadOnlyOptimal;
-
-        ResourceAccess access = {stages, vk::AccessFlagBits::eShaderRead, layout};
-        pass.AddDependency(access, resource);
-        return resource;
-    }
-
-    const Resource &PassBuilder::StorageRead(string_view name, PipelineStageMask stages) {
-        return StorageRead(GetID(name), stages);
-    }
-
-    const Resource &PassBuilder::StorageRead(ResourceID id, PipelineStageMask stages) {
-        auto &resource = resources.GetResourceRef(id);
-        ResourceAccess access = {
-            stages,
-            vk::AccessFlagBits::eShaderRead,
-        };
-        if (resource.type == Resource::Type::RenderTarget) {
-            resource.renderTargetDesc.usage |= vk::ImageUsageFlagBits::eStorage;
-            access.layout = vk::ImageLayout::eGeneral;
-        } else if (resource.type == Resource::Type::Buffer) {
-            resource.bufferDesc.usage |= vk::BufferUsageFlagBits::eStorageBuffer;
-        }
-        pass.AddDependency(access, resource);
-        return resource;
-    }
-
-    const Resource &PassBuilder::StorageWrite(string_view name, PipelineStageMask stages) {
-        return StorageWrite(GetID(name), stages);
-    }
-
-    const Resource &PassBuilder::StorageWrite(ResourceID id, PipelineStageMask stages) {
-        auto &resource = resources.GetResourceRef(id);
-        ResourceAccess access = {
-            stages,
-            vk::AccessFlagBits::eShaderWrite,
-        };
-        if (resource.type == Resource::Type::RenderTarget) {
-            resource.renderTargetDesc.usage |= vk::ImageUsageFlagBits::eStorage;
-            access.layout = vk::ImageLayout::eGeneral;
-        } else if (resource.type == Resource::Type::Buffer) {
-            resource.bufferDesc.usage |= vk::BufferUsageFlagBits::eStorageBuffer;
-        }
-        pass.AddDependency(access, resource);
-        return resource;
-    }
-
-    const Resource &PassBuilder::BufferAccess(string_view name,
-        PipelineStageMask stages,
-        AccessMask access,
-        BufferUsageMask usage) {
-        return BufferAccess(GetID(name), stages, access, usage);
-    }
-
-    const Resource &PassBuilder::BufferAccess(ResourceID id,
-        PipelineStageMask stages,
-        AccessMask accesses,
-        BufferUsageMask usage) {
-        auto &resource = resources.GetResourceRef(id);
-        ResourceAccess access = {
-            stages,
-            accesses,
-        };
-        resource.bufferDesc.usage |= usage;
-        pass.AddDependency(access, resource);
-        return resource;
-    }
-
-    Resource PassBuilder::RenderTargetCreate(string_view name, const RenderTargetDesc &desc) {
+    Resource PassBuilder::CreateRenderTarget(string_view name, const RenderTargetDesc &desc, Access access) {
         Resource resource(desc);
         resources.Register(name, resource);
-        pass.AddOutput(resource.id);
+        pass.AddCreate(resource.id, access);
         return resource;
     }
 
@@ -167,21 +73,14 @@ namespace sp::vulkan::render_graph {
     }
 
     void PassBuilder::SetDepthAttachment(ResourceID id, const AttachmentInfo &info) {
-        auto &res = resources.GetResourceRef(id);
-        Assert(res.type == Resource::Type::RenderTarget, "resource must be a render target");
-        res.renderTargetDesc.usage |= vk::ImageUsageFlagBits::eDepthStencilAttachment;
-        ResourceAccess access = {
-            vk::PipelineStageFlagBits::eEarlyFragmentTests,
-            vk::AccessFlagBits::eDepthStencilAttachmentRead | vk::AccessFlagBits::eDepthStencilAttachmentWrite,
-            vk::ImageLayout::eDepthStencilAttachmentOptimal,
-        };
-        pass.AddDependency(access, res);
+        Write(id, Access::DepthStencilAttachmentWrite);
         SetAttachment(MAX_COLOR_ATTACHMENTS, id, info);
     }
 
     Resource PassBuilder::OutputDepthAttachment(string_view name, RenderTargetDesc desc, const AttachmentInfo &info) {
-        desc.usage |= vk::ImageUsageFlagBits::eDepthStencilAttachment;
-        return OutputAttachment(MAX_COLOR_ATTACHMENTS, name, desc, info);
+        auto resource = CreateRenderTarget(name, desc, Access::DepthStencilAttachmentWrite);
+        SetAttachment(MAX_COLOR_ATTACHMENTS, resource.id, info);
+        return resource;
     }
 
     void PassBuilder::SetPrimaryAttachment(uint32 index) {
@@ -189,18 +88,18 @@ namespace sp::vulkan::render_graph {
         pass.primaryAttachmentIndex = index;
     }
 
-    Resource PassBuilder::BufferCreate(size_t size, BufferUsageMask usage, Residency residency) {
-        return BufferCreate("", size, usage, residency);
+    Resource PassBuilder::CreateBuffer(size_t size, Residency residency, Access access) {
+        return CreateBuffer("", size, residency, access);
     }
 
-    Resource PassBuilder::BufferCreate(string_view name, size_t size, BufferUsageMask usage, Residency residency) {
+    Resource PassBuilder::CreateBuffer(string_view name, size_t size, Residency residency, Access access) {
         BufferDesc desc;
         desc.size = size;
-        desc.usage = usage;
+        desc.usage |= AccessMap[(size_t)access].bufferUsageMask;
         desc.residency = residency;
         Resource resource(desc);
         resources.Register(name, resource);
-        pass.AddOutput(resource.id);
+        pass.AddCreate(resource.id, access);
         return resource;
     }
 
@@ -208,17 +107,12 @@ namespace sp::vulkan::render_graph {
         string_view name,
         const RenderTargetDesc &desc,
         const AttachmentInfo &info) {
-        auto resource = RenderTargetCreate(name, desc);
-        SetAttachmentWithoutOutput(index, resource.id, info);
+        auto resource = CreateRenderTarget(name, desc, Access::ColorAttachmentWrite);
+        SetAttachment(index, resource.id, info);
         return resource;
     }
 
     void PassBuilder::SetAttachment(uint32 index, ResourceID id, const AttachmentInfo &info) {
-        pass.AddOutput(id);
-        SetAttachmentWithoutOutput(index, id, info);
-    }
-
-    void PassBuilder::SetAttachmentWithoutOutput(uint32 index, ResourceID id, const AttachmentInfo &info) {
         auto &attachment = pass.attachments[index];
         attachment = info;
         attachment.resourceID = id;

--- a/src/graphics/graphics/vulkan/render_graph/RenderGraph.hh
+++ b/src/graphics/graphics/vulkan/render_graph/RenderGraph.hh
@@ -78,6 +78,7 @@ namespace sp::vulkan::render_graph {
         void BeginScope(string_view name);
         void EndScope();
 
+        // TODO: add SetRenderTarget etc. on Resources, allowing importing arbitrary resources in Execute
         void SetTargetImageView(string_view name, ImageViewPtr view);
 
         void RequireResource(string_view name) {
@@ -113,7 +114,8 @@ namespace sp::vulkan::render_graph {
 
     private:
         friend class InitialPassState;
-        void AddPassBarriers(CommandContextPtr &cmd, Pass &pass);
+        void AddPreBarriers(CommandContextPtr &cmd, Pass &pass);
+        void AddPostBarriers(CommandContextPtr &cmd, Pass &pass);
         void AdvanceFrame();
 
         void UpdateLastOutput(const Pass &pass) {

--- a/src/graphics/graphics/vulkan/render_graph/Resources.cc
+++ b/src/graphics/graphics/vulkan/render_graph/Resources.cc
@@ -42,6 +42,7 @@ namespace sp::vulkan::render_graph {
         refCounts.resize(resources.size());
         renderTargets.resize(resources.size());
         buffers.resize(resources.size());
+        lastResourceAccess.resize(resources.size());
     }
 
     RenderTargetPtr Resources::GetRenderTarget(string_view name) {
@@ -134,6 +135,16 @@ namespace sp::vulkan::render_graph {
             break;
         default:
             Abort("resource type is undefined");
+        }
+    }
+
+    void Resources::AddUsageFromAccess(ResourceID id, Access access) {
+        auto &res = GetResourceRef(id);
+        auto &acc = AccessMap[(size_t)access];
+        if (res.type == Resource::Type::RenderTarget) {
+            res.renderTargetDesc.usage |= acc.imageUsageMask;
+        } else if (res.type == Resource::Type::Buffer) {
+            res.bufferDesc.usage |= acc.bufferUsageMask;
         }
     }
 

--- a/src/graphics/graphics/vulkan/render_graph/Resources.hh
+++ b/src/graphics/graphics/vulkan/render_graph/Resources.hh
@@ -5,6 +5,7 @@
 #include "graphics/vulkan/core/Common.hh"
 #include "graphics/vulkan/core/Memory.hh"
 #include "graphics/vulkan/core/RenderTarget.hh"
+#include "graphics/vulkan/render_graph/Access.hh"
 
 #include <robin_hood.h>
 
@@ -90,6 +91,7 @@ namespace sp::vulkan::render_graph {
         uint32 RefCount(ResourceID id);
         void IncrementRef(ResourceID id);
         void DecrementRef(ResourceID id);
+        void AddUsageFromAccess(ResourceID id, Access access);
 
         ResourceID ReserveID(string_view name);
         void Register(string_view name, Resource &resource);
@@ -132,6 +134,8 @@ namespace sp::vulkan::render_graph {
         vector<int32> refCounts;
         vector<RenderTargetPtr> renderTargets;
         vector<BufferPtr> buffers;
+
+        vector<Access> lastResourceAccess;
 
         ResourceID lastOutputID = InvalidResource;
     };

--- a/src/graphics/graphics/vulkan/render_passes/Bloom.cc
+++ b/src/graphics/graphics/vulkan/render_passes/Bloom.cc
@@ -19,12 +19,12 @@ namespace sp::vulkan::renderer {
 
         graph.AddPass("BloomCombine")
             .Build([&](rg::PassBuilder &builder) {
-                auto source = builder.TextureRead(sourceID);
-                auto desc = source.DeriveRenderTarget();
+                builder.Read(sourceID, Access::FragmentShaderSampleImage);
+                auto desc = builder.DeriveRenderTarget(sourceID);
                 builder.OutputColorAttachment(0, "Bloom", desc, {LoadOp::DontCare, StoreOp::Store});
 
-                builder.TextureRead(blur1);
-                builder.TextureRead(blur2);
+                builder.Read(blur1, Access::FragmentShaderSampleImage);
+                builder.Read(blur2, Access::FragmentShaderSampleImage);
             })
             .Execute([sourceID, blur1, blur2](rg::Resources &resources, CommandContext &cmd) {
                 cmd.SetShaders("screen_cover.vert", "bloom_combine.frag");

--- a/src/graphics/graphics/vulkan/render_passes/Blur.cc
+++ b/src/graphics/graphics/vulkan/render_passes/Blur.cc
@@ -23,8 +23,9 @@ namespace sp::vulkan::renderer {
 
         return graph.AddPass("GaussianBlur")
             .Build([&](PassBuilder &builder) {
-                auto source = builder.TextureRead(sourceID);
-                auto desc = source.DeriveRenderTarget();
+                builder.Read(sourceID, Access::FragmentShaderSampleImage);
+
+                auto desc = builder.DeriveRenderTarget(sourceID);
                 desc.extent.width = std::max(desc.extent.width / downsample, 1u);
                 desc.extent.height = std::max(desc.extent.height / downsample, 1u);
                 builder.OutputColorAttachment(0, "", desc, {LoadOp::DontCare, StoreOp::Store});

--- a/src/graphics/graphics/vulkan/render_passes/Emissive.cc
+++ b/src/graphics/graphics/vulkan/render_passes/Emissive.cc
@@ -48,15 +48,15 @@ namespace sp::vulkan::renderer {
         graph.AddPass("Emissive")
             .Build([&](PassBuilder &builder) {
                 auto input = builder.LastOutput();
-                builder.TextureRead(input.id);
-                builder.TextureRead("GBuffer0");
-                builder.TextureRead("GBuffer1");
-                builder.StorageRead("ExposureState");
+                builder.Read(input.id, Access::FragmentShaderSampleImage);
+                builder.Read("GBuffer0", Access::FragmentShaderSampleImage);
+                builder.Read("GBuffer1", Access::FragmentShaderSampleImage);
+                builder.Read("ExposureState", Access::FragmentShaderReadStorage);
 
                 auto desc = input.DeriveRenderTarget();
                 builder.OutputColorAttachment(0, "Emissive", desc, {LoadOp::DontCare, StoreOp::Store});
 
-                builder.UniformRead("ViewState");
+                builder.ReadUniform("ViewState");
 
                 builder.SetDepthAttachment("GBufferDepthStencil", {LoadOp::Load, StoreOp::Store});
 
@@ -64,10 +64,10 @@ namespace sp::vulkan::renderer {
                     if (!ent.Has<ecs::Transform>(lock)) continue;
 
                     auto &screenComp = ent.Get<ecs::Screen>(lock);
-                    auto &resource = builder.TextureRead(screenComp.textureName);
+                    auto id = builder.Read(screenComp.textureName, Access::FragmentShaderSampleImage);
 
                     Screen screen;
-                    screen.id = resource.id;
+                    screen.id = id;
                     screen.gpuData.luminanceScale = screenComp.luminanceScale;
                     screen.gpuData.quad = ent.Get<ecs::TransformSnapshot>(lock).matrix;
                     screens.push_back(std::move(screen));

--- a/src/graphics/graphics/vulkan/render_passes/Screenshots.cc
+++ b/src/graphics/graphics/vulkan/render_passes/Screenshots.cc
@@ -41,7 +41,7 @@ namespace sp::vulkan::renderer {
                         } else {
                             sourceID = VisualizeBuffer(graph, resource.id);
                         }
-                        builder.TransferRead(sourceID);
+                        builder.Read(sourceID, rg::Access::TransferRead);
                         builder.RequirePass();
                     }
                 })

--- a/src/graphics/graphics/vulkan/render_passes/Tonemap.cc
+++ b/src/graphics/graphics/vulkan/render_passes/Tonemap.cc
@@ -6,9 +6,10 @@ namespace sp::vulkan::renderer {
     void AddTonemap(RenderGraph &graph) {
         graph.AddPass("Tonemap")
             .Build([&](rg::PassBuilder &builder) {
-                auto luminance = builder.TextureRead(builder.LastOutputID());
+                auto luminanceID = builder.LastOutputID();
+                builder.Read(luminanceID, Access::FragmentShaderSampleImage);
 
-                auto desc = luminance.DeriveRenderTarget();
+                auto desc = builder.DeriveRenderTarget(luminanceID);
                 desc.format = vk::Format::eR8G8B8A8Srgb;
                 builder.OutputColorAttachment(0, "TonemappedLuminance", desc, {LoadOp::DontCare, StoreOp::Store});
             })

--- a/src/graphics/graphics/vulkan/render_passes/VisualizeBuffer.cc
+++ b/src/graphics/graphics/vulkan/render_passes/VisualizeBuffer.cc
@@ -5,17 +5,17 @@
 
 namespace sp::vulkan::renderer {
     ResourceID VisualizeBuffer(RenderGraph &graph, ResourceID sourceID, uint32 arrayLayer) {
-        ResourceID targetID = InvalidResource, outputID;
+        ResourceID outputID;
         graph.AddPass("VisualizeBuffer")
             .Build([&](PassBuilder &builder) {
-                auto &res = builder.TextureRead(sourceID);
-                targetID = res.id;
-                auto desc = res.DeriveRenderTarget();
+                builder.Read(sourceID, Access::FragmentShaderSampleImage);
+
+                auto desc = builder.DeriveRenderTarget(sourceID);
                 desc.format = vk::Format::eR8G8B8A8Srgb;
                 outputID = builder.OutputColorAttachment(0, "", desc, {LoadOp::DontCare, StoreOp::Store}).id;
             })
-            .Execute([targetID, arrayLayer](Resources &resources, CommandContext &cmd) {
-                auto target = resources.GetRenderTarget(targetID);
+            .Execute([sourceID, arrayLayer](Resources &resources, CommandContext &cmd) {
+                auto target = resources.GetRenderTarget(sourceID);
                 ImageViewPtr source;
                 if (target->Desc().arrayLayers > 1 && arrayLayer != ~0u && arrayLayer < target->Desc().arrayLayers) {
                     source = target->LayerImageView(arrayLayer);


### PR DESCRIPTION
We were previously missing several barriers (and generating wrong barriers) that could lead to corrupted buffers and other memory hazards. Now, it's much harder to miss barriers since they're generated for you in the vast majority of cases as long as you accurately tell the render graph how a resource is going to be accessed.

Buffer usage and image usage can now be inferred. If a new graph pass needs to use a resources in a new way, that usage will automatically be included in the flags when the resource is created, without having to update the pass that creates the resource.

The `render_graph::Access` enum defines how an access maps to Vulkan pipeline stages, access flags, usage flags, and image layouts. It's inspired by https://github.com/Tobski/simple_vulkan_synchronization/blob/master/thsvs_simpler_vulkan_synchronization.h and aims to produce optimal barriers (fine grained declaration of when and how resources are used) without nearly as much complexity. I didn't add every possible access type to our enum, but I think I got the ones we're likely to use any time soon, and it's easy to add more.