### PR TITLE
render_graph: Only submit pending commands when a pass declares it or execution finishes

### DIFF
--- a/src/graphics/graphics/vulkan/Renderer.cc
+++ b/src/graphics/graphics/vulkan/Renderer.cc
@@ -375,6 +375,7 @@ namespace sp::vulkan {
                 }
 
                 builder.Read(sourceID, Access::TransferRead);
+                builder.FlushCommands();
                 builder.RequirePass();
             })
             .Execute([this, sourceID](rg::Resources &resources, DeviceContext &device) {

--- a/src/graphics/graphics/vulkan/core/CommandContext.cc
+++ b/src/graphics/graphics/vulkan/core/CommandContext.cc
@@ -460,6 +460,8 @@ namespace sp::vulkan {
     }
 
     vk::Fence CommandContext::Fence() {
+        if (abandoned) return {};
+
         if (!fence && scope == CommandContextScope::Fence) {
             vk::FenceCreateInfo fenceInfo;
             fence = device->createFenceUnique(fenceInfo);

--- a/src/graphics/graphics/vulkan/core/DeviceContext.hh
+++ b/src/graphics/graphics/vulkan/core/DeviceContext.hh
@@ -233,6 +233,7 @@ namespace sp::vulkan {
 
         std::array<vk::Queue, QUEUE_TYPES_COUNT> queues;
         std::array<uint32, QUEUE_TYPES_COUNT> queueFamilyIndex;
+        std::array<uint32, QUEUE_TYPES_COUNT> queueLastSubmit;
         vk::Extent3D imageTransferGranularity;
 
         vk::UniqueSwapchainKHR swapchain;

--- a/src/graphics/graphics/vulkan/render_graph/Pass.hh
+++ b/src/graphics/graphics/vulkan/render_graph/Pass.hh
@@ -80,6 +80,7 @@ namespace sp::vulkan::render_graph {
         bool active = false, required = false;
         uint8 primaryAttachmentIndex = 0;
         bool isRenderPass = false;
+        bool flushCommands = false; // true will submit pending command buffers
 
         std::variant<std::monostate,
             std::function<void(Resources &, CommandContext &)>,

--- a/src/graphics/graphics/vulkan/render_graph/PassBuilder.hh
+++ b/src/graphics/graphics/vulkan/render_graph/PassBuilder.hh
@@ -63,6 +63,11 @@ namespace sp::vulkan::render_graph {
             return resources.LastOutput();
         }
 
+        // Indicates pending command buffers should be submitted before Execute is called
+        void FlushCommands() {
+            pass.flushCommands = true;
+        }
+
         void RequirePass() {
             pass.required = true;
         }

--- a/src/graphics/graphics/vulkan/render_graph/RenderGraph.cc
+++ b/src/graphics/graphics/vulkan/render_graph/RenderGraph.cc
@@ -80,6 +80,8 @@ namespace sp::vulkan::render_graph {
 
             Assert(pass.HasExecute(), "pass must have an Execute function");
 
+            if (pass.flushCommands) submitPendingCmds();
+
             RenderPassInfo renderPassInfo;
 
             for (uint32 i = 0; i < pass.attachments.size(); i++) {
@@ -162,7 +164,6 @@ namespace sp::vulkan::render_graph {
                 pass.Execute(resources, *cmd);
                 cmd->EndRenderPass();
             } else if (pass.ExecutesWithDeviceContext()) {
-                submitPendingCmds();
                 RenderPhase phase(pass.name);
                 if (timer) phase.StartTimer(*timer);
                 pass.Execute(resources, device);

--- a/src/graphics/graphics/vulkan/render_passes/Emissive.cc
+++ b/src/graphics/graphics/vulkan/render_passes/Emissive.cc
@@ -50,11 +50,9 @@ namespace sp::vulkan::renderer {
                 builder.Read("GBuffer0", Access::FragmentShaderSampleImage);
                 builder.Read("GBuffer1", Access::FragmentShaderSampleImage);
                 builder.Read("ExposureState", Access::FragmentShaderReadStorage);
-
-                builder.SetColorAttachment(0, builder.LastOutputID(), {LoadOp::Load, StoreOp::Store});
-
                 builder.ReadUniform("ViewState");
 
+                builder.SetColorAttachment(0, builder.LastOutputID(), {LoadOp::Load, StoreOp::Store});
                 builder.SetDepthAttachment("GBufferDepthStencil", {LoadOp::Load, StoreOp::Store});
 
                 for (auto ent : lock.EntitiesWith<ecs::Screen>()) {


### PR DESCRIPTION
Also, don't attempt to TracyVkCollect on a queue unless that queue had work submitted last frame. If there were no traces on that frame, Tracy will not record any commands to the command buffer, but it would previously have been submitted anyway. If there were no other commands on that queue for a while, that submission batch's fence would never be signaled, and the CommandContext that owns the buffer would not be reusable until the fence is triggered by something else. This caused buildups of hundreds of pending CommandContexts on the compute queue, which is used rarely for image factor compute at the moment.