### PR TITLE
Add readback helpers, track array stride in runtime sized array buffers

### DIFF
--- a/src/graphics/graphics/vulkan/core/BufferPool.cc
+++ b/src/graphics/graphics/vulkan/core/BufferPool.cc
@@ -15,7 +15,7 @@ namespace sp::vulkan {
             return buffer;
         }
 
-        bufferList.pending.push_back(device.AllocateBuffer(desc.size, desc.usage, (VmaMemoryUsage)desc.residency));
+        bufferList.pending.push_back(device.AllocateBuffer(desc.layout, desc.usage, (VmaMemoryUsage)desc.residency));
         return bufferList.pending.back();
     }
 

--- a/src/graphics/graphics/vulkan/core/CommandContext.cc
+++ b/src/graphics/graphics/vulkan/core/CommandContext.cc
@@ -320,6 +320,7 @@ namespace sp::vulkan {
         bufferBinding.buffer = **buffer;
         bufferBinding.offset = 0;
         bufferBinding.range = buffer->Size();
+        bindingDesc.arrayStride = buffer->ArrayStride();
         SetDescriptorDirty(set);
     }
 
@@ -333,12 +334,13 @@ namespace sp::vulkan {
         bufferBinding.buffer = **buffer;
         bufferBinding.offset = 0;
         bufferBinding.range = buffer->Size();
+        bindingDesc.arrayStride = buffer->ArrayStride();
         SetDescriptorDirty(set);
     }
 
     BufferPtr CommandContext::AllocUniformBuffer(uint32 set, uint32 binding, vk::DeviceSize size) {
         BufferDesc desc;
-        desc.size = size;
+        desc.layout = size;
         desc.usage = vk::BufferUsageFlagBits::eUniformBuffer;
         desc.residency = Residency::CPU_TO_GPU;
         auto buffer = device.GetBuffer(desc);

--- a/src/graphics/graphics/vulkan/core/DeviceContext.cc
+++ b/src/graphics/graphics/vulkan/core/DeviceContext.cc
@@ -864,13 +864,13 @@ namespace sp::vulkan {
         }
     }
 
-    BufferPtr DeviceContext::AllocateBuffer(vk::DeviceSize size, vk::BufferUsageFlags usage, VmaMemoryUsage residency) {
+    BufferPtr DeviceContext::AllocateBuffer(BufferLayout layout, vk::BufferUsageFlags usage, VmaMemoryUsage residency) {
         vk::BufferCreateInfo bufferInfo;
-        bufferInfo.size = size;
+        bufferInfo.size = layout.size;
         bufferInfo.usage = usage;
         VmaAllocationCreateInfo allocInfo = {};
         allocInfo.usage = residency;
-        return make_shared<Buffer>(bufferInfo, allocInfo, allocator.get());
+        return make_shared<Buffer>(bufferInfo, allocInfo, allocator.get(), layout.arrayStride, layout.arrayCount);
     }
 
     BufferPtr DeviceContext::AllocateBuffer(vk::BufferCreateInfo bufferInfo, VmaAllocationCreateInfo allocInfo) {

--- a/src/graphics/graphics/vulkan/core/Pipeline.hh
+++ b/src/graphics/graphics/vulkan/core/Pipeline.hh
@@ -67,7 +67,7 @@ namespace sp::vulkan {
         DescriptorSetLayoutInfo descriptorSets[MAX_BOUND_DESCRIPTOR_SETS];
 
         struct MemorySize {
-            VkDeviceSize sizeBase = 0, sizeIncrement = 0;
+            vk::DeviceSize sizeBase = 0, sizeIncrement = 0;
         };
         std::array<std::array<MemorySize, MAX_BINDINGS_PER_DESCRIPTOR_SET>, MAX_BOUND_DESCRIPTOR_SETS> sizes;
     };

--- a/src/graphics/graphics/vulkan/core/Shader.hh
+++ b/src/graphics/graphics/vulkan/core/Shader.hh
@@ -61,6 +61,7 @@ namespace sp::vulkan {
         };
         vk::DeviceSize offset;
         UniqueID uniqueID = 0;
+        uint32 arrayStride = 0;
     };
 
     struct DescriptorSetBindings {

--- a/src/graphics/graphics/vulkan/gui/GuiRenderer.cc
+++ b/src/graphics/graphics/vulkan/gui/GuiRenderer.cc
@@ -123,13 +123,13 @@ namespace sp::vulkan {
         if (totalVtxSize == 0 || totalIdxSize == 0) return;
 
         BufferDesc vtxDesc;
-        vtxDesc.size = totalVtxSize;
+        vtxDesc.layout = totalVtxSize;
         vtxDesc.usage = vk::BufferUsageFlagBits::eVertexBuffer;
         vtxDesc.residency = Residency::CPU_TO_GPU;
         auto vertexBuffer = cmd.Device().GetBuffer(vtxDesc);
 
         BufferDesc idxDesc;
-        idxDesc.size = totalIdxSize;
+        idxDesc.layout = totalIdxSize;
         idxDesc.usage = vk::BufferUsageFlagBits::eIndexBuffer;
         idxDesc.residency = Residency::CPU_TO_GPU;
         auto indexBuffer = cmd.Device().GetBuffer(idxDesc);

--- a/src/graphics/graphics/vulkan/render_graph/PassBuilder.cc
+++ b/src/graphics/graphics/vulkan/render_graph/PassBuilder.cc
@@ -87,15 +87,15 @@ namespace sp::vulkan::render_graph {
         pass.primaryAttachmentIndex = index;
     }
 
-    Resource PassBuilder::CreateBuffer(size_t size, Residency residency, Access access) {
-        return CreateBuffer("", size, residency, access);
+    Resource PassBuilder::CreateBuffer(BufferLayout layout, Residency residency, Access access) {
+        return CreateBuffer("", layout, residency, access);
     }
 
-    Resource PassBuilder::CreateBuffer(string_view name, size_t size, Residency residency, Access access) {
-        Assert(size > 0, "can't create a buffer of size 0");
+    Resource PassBuilder::CreateBuffer(string_view name, BufferLayout layout, Residency residency, Access access) {
+        Assert(layout.size > 0, "can't create a buffer of size 0");
 
         BufferDesc desc;
-        desc.size = size;
+        desc.layout = layout;
         desc.residency = residency;
         Resource resource(desc);
         resources.Register(name, resource);

--- a/src/graphics/graphics/vulkan/render_graph/PassBuilder.hh
+++ b/src/graphics/graphics/vulkan/render_graph/PassBuilder.hh
@@ -46,8 +46,8 @@ namespace sp::vulkan::render_graph {
             return resources.GetResourceRef(id).DeriveImage();
         }
 
-        Resource CreateBuffer(size_t size, Residency residency, Access access);
-        Resource CreateBuffer(string_view name, size_t size, Residency residency, Access access);
+        Resource CreateBuffer(BufferLayout layout, Residency residency, Access access);
+        Resource CreateBuffer(string_view name, BufferLayout layout, Residency residency, Access access);
 
         Resource CreateUniform(string_view name, size_t size) {
             return CreateBuffer(name, size, Residency::CPU_TO_GPU, Access::HostWrite);

--- a/src/graphics/graphics/vulkan/render_graph/Resources.hh
+++ b/src/graphics/graphics/vulkan/render_graph/Resources.hh
@@ -44,8 +44,16 @@ namespace sp::vulkan::render_graph {
             return imageDesc.format;
         }
 
+        vk::Extent3D ImageExtents() const {
+            return imageDesc.extent;
+        }
+
+        uint32 ImageLayers() const {
+            return imageDesc.arrayLayers;
+        }
+
         size_t BufferSize() const {
-            return bufferDesc.size;
+            return bufferDesc.layout.size;
         }
 
         ResourceID id = InvalidResource;

--- a/src/graphics/graphics/vulkan/render_passes/Readback.hh
+++ b/src/graphics/graphics/vulkan/render_passes/Readback.hh
@@ -1,0 +1,121 @@
+#pragma once
+
+#include "Common.hh"
+#include "graphics/vulkan/core/CommandContext.hh"
+#include "graphics/vulkan/core/DeviceContext.hh"
+
+namespace sp::vulkan::renderer {
+    /**
+     * Copies a buffer to the CPU.
+     * After the copy is done, at the end of the frame, the callback is called with a BufferPtr containing the data.
+     * The buffer will be mappable for access on the CPU.
+     */
+    template<typename Callback, typename ResourceName>
+    void AddBufferReadback(RenderGraph &graph,
+        ResourceName resourceID,
+        vk::DeviceSize srcOffset,
+        vk::DeviceSize size, // pass 0 to copy until the end of the buffer
+        Callback &&callback) {
+
+        ResourceID readbackID = InvalidResource;
+        vk::BufferCopy region;
+        region.srcOffset = srcOffset;
+        region.dstOffset = 0;
+        region.size = size;
+
+        graph.AddPass("TransferForBufferReadback")
+            .Build([&](rg::PassBuilder &builder) {
+                auto resource = builder.GetResource(resourceID);
+                Assert(resource.type == Resource::Type::Buffer, "resource must be a buffer");
+                builder.Read(resource.id, Access::TransferRead);
+
+                if (region.size == 0) region.size = resource.BufferSize() - region.srcOffset;
+                readbackID = builder.CreateBuffer(region.size, Residency::GPU_TO_CPU, Access::TransferWrite).id;
+            })
+            .Execute([resourceID, readbackID, region](rg::Resources &resources, CommandContext &cmd) {
+                auto srcBuffer = resources.GetBuffer(resourceID);
+                auto dstBuffer = resources.GetBuffer(readbackID);
+                cmd.Raw().copyBuffer(*srcBuffer, *dstBuffer, {region});
+            });
+
+        graph.AddPass("BufferReadback")
+            .Build([&](rg::PassBuilder &builder) {
+                builder.RequirePass();
+                builder.Read(readbackID, Access::HostRead);
+            })
+            .Execute([readbackID, callback](rg::Resources &resources, DeviceContext &device) {
+                auto buffer = resources.GetBuffer(readbackID);
+                device.ExecuteAfterFrameFence([callback, buffer]() {
+                    callback(buffer);
+                });
+            });
+    }
+
+    /**
+     * Copies an image to the CPU.
+     * After the copy is done, at the end of the frame, the callback is called with a BufferPtr containing the data.
+     * The buffer will be mappable for access on the CPU.
+     */
+    template<typename Callback, typename ResourceName>
+    void AddImageReadback(RenderGraph &graph,
+        ResourceName resourceID,
+        vk::ImageSubresourceLayers subresource, // pass {} for all layers
+        vk::Offset3D offset, // pass {} for no offset
+        vk::Extent3D extent, // pass {} to copy from the offset to the image's full extent
+        Callback &&callback) {
+
+        ResourceID readbackID = InvalidResource;
+        vk::BufferImageCopy region;
+        region.bufferOffset = 0;
+        region.bufferRowLength = 0;
+        region.bufferImageHeight = 0;
+        region.imageSubresource = subresource;
+        region.imageOffset = offset;
+        region.imageExtent = extent;
+
+        graph.AddPass("TransferForImageReadback")
+            .Build([&](rg::PassBuilder &builder) {
+                auto resource = builder.GetResource(resourceID);
+                Assert(resource.type == Resource::Type::Image, "resource must be an image");
+                builder.Read(resource.id, Access::TransferRead);
+
+                if (region.imageExtent == vk::Extent3D{}) {
+                    region.imageExtent = resource.ImageExtents();
+                    region.imageExtent.width -= region.imageOffset.x;
+                    region.imageExtent.height -= region.imageOffset.y;
+                    region.imageExtent.depth -= region.imageOffset.z;
+                }
+
+                if (region.imageSubresource.layerCount == 0) {
+                    region.imageSubresource.layerCount = resource.ImageLayers();
+                }
+
+                if (!region.imageSubresource.aspectMask) {
+                    region.imageSubresource.aspectMask = FormatToAspectFlags(resource.ImageFormat());
+                }
+
+                auto texels = region.imageExtent.width * region.imageExtent.height * region.imageExtent.depth *
+                              region.imageSubresource.layerCount;
+
+                auto bufferSize = FormatByteSize(resource.ImageFormat()) * texels;
+                readbackID = builder.CreateBuffer(bufferSize, Residency::GPU_TO_CPU, Access::TransferWrite).id;
+            })
+            .Execute([resourceID, readbackID, region](rg::Resources &resources, CommandContext &cmd) {
+                auto srcImage = resources.GetImageView(resourceID)->Image();
+                auto dstBuffer = resources.GetBuffer(readbackID);
+                cmd.Raw().copyImageToBuffer(*srcImage, srcImage->LastLayout(), *dstBuffer, {region});
+            });
+
+        graph.AddPass("ImageReadback")
+            .Build([&](rg::PassBuilder &builder) {
+                builder.RequirePass();
+                builder.Read(readbackID, Access::HostRead);
+            })
+            .Execute([readbackID, callback](rg::Resources &resources, DeviceContext &device) {
+                auto buffer = resources.GetBuffer(readbackID);
+                device.ExecuteAfterFrameFence([callback, buffer]() {
+                    callback(buffer);
+                });
+            });
+    }
+} // namespace sp::vulkan::renderer

--- a/src/graphics/graphics/vulkan/render_passes/Voxels.cc
+++ b/src/graphics/graphics/vulkan/render_passes/Voxels.cc
@@ -4,6 +4,7 @@
 #include "graphics/vulkan/core/DeviceContext.hh"
 #include "graphics/vulkan/render_passes/Blur.hh"
 #include "graphics/vulkan/render_passes/Lighting.hh"
+#include "graphics/vulkan/render_passes/Readback.hh"
 
 namespace sp::vulkan::renderer {
     static CVar<int> CVarVoxelDebug("r.VoxelDebug",
@@ -78,7 +79,9 @@ namespace sp::vulkan::renderer {
 
         struct GPUVoxelFragment {
             uint16_t position[3];
+            uint16_t _padding0[1];
             uint16_t radiance[3]; // half-float formatted
+            uint16_t _padding1[1];
         };
 
         struct GPUVoxelFragmentList {
@@ -141,7 +144,7 @@ namespace sp::vulkan::renderer {
 
                 for (size_t i = 0; i < CVarVoxelFragmentBuckets.Get() && i < MAX_VOXEL_FRAGMENT_LISTS; i++) {
                     auto buf = builder.CreateBuffer(
-                        sizeof(GPUVoxelFragmentList) + sizeof(GPUVoxelFragment) * fragmentListSize,
+                        {sizeof(GPUVoxelFragmentList), sizeof(GPUVoxelFragment), (size_t)fragmentListSize},
                         Residency::GPU_ONLY,
                         Access::TransferWrite);
                     fragmentListBuffers.emplace_back(buf.id);
@@ -303,37 +306,10 @@ namespace sp::vulkan::renderer {
                 });
         }
 
-        // graph.AddPass("FillReadback")
-        //     .Build([&](rg::PassBuilder &builder) {
-        //         builder.Read(fragmentListBuffers[0], Access::TransferRead);
-
-        //         builder.CreateBuffer("FillReadback",
-        //             sizeof(GPUVoxelFragmentList),
-        //             Residency::GPU_TO_CPU,
-        //             Access::TransferWrite);
-        //     })
-        //     .Execute([this](rg::Resources &resources, CommandContext &cmd) {
-        //         auto srcBuffer = resources.GetBuffer(fragmentListBuffers[0]);
-        //         auto dstBuffer = resources.GetBuffer("FillReadback");
-
-        //         vk::BufferCopy region;
-        //         region.size = sizeof(GPUVoxelFragmentList);
-        //         cmd.Raw().copyBuffer(*srcBuffer, *dstBuffer, {region});
-        //     });
-
-        // graph.AddPass("FillReadback2")
-        //     .Build([&](rg::PassBuilder &builder) {
-        //         builder.RequirePass();
-        //         builder.ReadPreviousFrame("FillReadback", Access::HostRead);
-        //     })
-        //     .Execute([this](rg::Resources &resources, CommandContext &cmd) {
-        //         auto resourceId = resources.GetID("FillReadback", false, 1);
-        //         if (resourceId == InvalidResource) return;
-
-        //         auto buffer = resources.GetBuffer(resourceId);
-        //         auto map = (const GPUVoxelFragmentList *)buffer->Mapped();
-        //         Logf("Fragment count: %u", map->count);
-        //     });
+        // AddBufferReadback(graph, fragmentListBuffers[0], 0, sizeof(GPUVoxelFragmentList), [](BufferPtr buffer) {
+        //     auto map = (const GPUVoxelFragmentList *)buffer->Mapped();
+        //     Logf("Fragment count: %u", map->count);
+        // });
     }
 
     void Voxels::AddDebugPass(RenderGraph &graph) {

--- a/src/graphics/graphics/vulkan/scene/Mesh.cc
+++ b/src/graphics/graphics/vulkan/scene/Mesh.cc
@@ -28,11 +28,11 @@ namespace sp::vulkan {
             vertexCount += assetPrimitive.positionBuffer.Count();
         }
 
-        indexBuffer = scene.indexBuffer->ArrayAllocate(indexCount, sizeof(uint32));
+        indexBuffer = scene.indexBuffer->ArrayAllocate(indexCount);
         auto indexData = (uint32 *)indexBuffer->Mapped();
         auto indexDataStart = indexData;
 
-        vertexBuffer = scene.vertexBuffer->ArrayAllocate(vertexCount, sizeof(SceneVertex));
+        vertexBuffer = scene.vertexBuffer->ArrayAllocate(vertexCount);
         auto vertexData = (SceneVertex *)vertexBuffer->Mapped();
         auto vertexDataStart = vertexData;
 
@@ -72,8 +72,8 @@ namespace sp::vulkan {
                 TextureType::MetallicRoughness);
         }
 
-        primitiveList = scene.primitiveLists->ArrayAllocate(primitives.size(), sizeof(GPUMeshPrimitive));
-        modelEntry = scene.models->ArrayAllocate(1, sizeof(GPUMeshModel));
+        primitiveList = scene.primitiveLists->ArrayAllocate(primitives.size());
+        modelEntry = scene.models->ArrayAllocate(1);
 
         auto meshModel = (GPUMeshModel *)modelEntry->Mapped();
         auto gpuPrimitives = (GPUMeshPrimitive *)primitiveList->Mapped();


### PR DESCRIPTION
This makes the buffer compatibility validation much more accurate. The only cases that will be missed now are interior alignment issues that don't affect the size of the buffer or the stride of the array at the end of the buffer.