### PR TITLE
Remove some allocations from the renderer to speed up execution

### DIFF
--- a/src/graphics/graphics/vulkan/render_graph/RenderGraph.hh
+++ b/src/graphics/graphics/vulkan/render_graph/RenderGraph.hh
@@ -53,12 +53,12 @@ namespace sp::vulkan::render_graph {
              *     .Execute([](rg::Resources &resources, CommandContext &cmd) {
              *     });
              */
-            ResourceID Execute(std::function<void(Resources &, CommandContext &)> executeFunc) {
+            ResourceID Execute(std::function<void(Resources &, CommandContext &)> &&executeFunc) {
                 Assert(passIndex != ~0u, "Build must be called before Execute");
                 Assert(executeFunc, "Execute function must be defined");
                 auto &pass = graph.passes[passIndex];
                 Assert(!pass.HasExecute(), "multiple Execute functions for the same pass");
-                pass.executeFunc = executeFunc;
+                pass.executeFunc = std::move(executeFunc);
                 return graph.LastOutputID();
             }
 
@@ -77,12 +77,12 @@ namespace sp::vulkan::render_graph {
              *     .Execute([](rg::Resources &resources, DeviceContext &device) {
              *     });
              */
-            ResourceID Execute(std::function<void(Resources &, DeviceContext &)> executeFunc) {
+            ResourceID Execute(std::function<void(Resources &, DeviceContext &)> &&executeFunc) {
                 Assert(passIndex != ~0u, "Build must be called before Execute");
                 Assert(executeFunc, "Execute function must be defined");
                 auto &pass = graph.passes[passIndex];
                 Assert(!pass.HasExecute(), "multiple Execute functions for the same pass");
-                pass.executeFunc = executeFunc;
+                pass.executeFunc = std::move(executeFunc);
                 return graph.LastOutputID();
             }
 

--- a/src/graphics/graphics/vulkan/render_passes/Lighting.cc
+++ b/src/graphics/graphics/vulkan/render_passes/Lighting.cc
@@ -29,6 +29,7 @@ namespace sp::vulkan::renderer {
 
     void Lighting::LoadState(RenderGraph &graph,
         ecs::Lock<ecs::Read<ecs::Light, ecs::OpticalElement, ecs::TransformSnapshot>> lock) {
+        ZoneScoped;
         gelTextureCache.clear();
         lights.clear();
 
@@ -250,6 +251,7 @@ namespace sp::vulkan::renderer {
     }
 
     void Lighting::AddShadowPasses(RenderGraph &graph) {
+        ZoneScoped;
         graph.BeginScope("ShadowMap");
 
         ecs::Renderable::VisibilityMask opticMask;

--- a/src/graphics/graphics/vulkan/render_passes/Readback.hh
+++ b/src/graphics/graphics/vulkan/render_passes/Readback.hh
@@ -43,9 +43,9 @@ namespace sp::vulkan::renderer {
                 builder.RequirePass();
                 builder.Read(readbackID, Access::HostRead);
             })
-            .Execute([readbackID, callback](rg::Resources &resources, DeviceContext &device) {
+            .Execute([readbackID, callback = std::move(callback)](rg::Resources &resources, DeviceContext &device) {
                 auto buffer = resources.GetBuffer(readbackID);
-                device.ExecuteAfterFrameFence([callback, buffer]() {
+                device.ExecuteAfterFrameFence([callback = std::move(callback), buffer]() {
                     callback(buffer);
                 });
             });
@@ -111,9 +111,9 @@ namespace sp::vulkan::renderer {
                 builder.RequirePass();
                 builder.Read(readbackID, Access::HostRead);
             })
-            .Execute([readbackID, callback](rg::Resources &resources, DeviceContext &device) {
+            .Execute([readbackID, callback = std::move(callback)](rg::Resources &resources, DeviceContext &device) {
                 auto buffer = resources.GetBuffer(readbackID);
-                device.ExecuteAfterFrameFence([callback, buffer]() {
+                device.ExecuteAfterFrameFence([callback = std::move(callback), buffer]() {
                     callback(buffer);
                 });
             });

--- a/src/graphics/graphics/vulkan/render_passes/Voxels.cc
+++ b/src/graphics/graphics/vulkan/render_passes/Voxels.cc
@@ -54,6 +54,7 @@ namespace sp::vulkan::renderer {
     }
 
     void Voxels::AddVoxelization(RenderGraph &graph, const Lighting &lighting) {
+        ZoneScoped;
         auto scope = graph.Scope("Voxels");
 
         if (voxelGridSize == glm::ivec3(0)) {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/984857/166337337-eff94022-e76d-4c95-ab4e-f8fd80add9ec.png)

After:
![image](https://user-images.githubusercontent.com/984857/166337310-a7553cae-f459-4f1b-b310-03092b0ee462.png)

The stream of string allocations during GPUScene::LoadState are gone, which speeds it and BuildFrameGraph up a lot. Avoiding copies of the callbacks removed some of the tall spikes.