### PR TITLE
AudioManager: don't assert on user-triggered errors

### DIFF
--- a/src/audio/audio/AudioManager.hh
+++ b/src/audio/audio/AudioManager.hh
@@ -33,14 +33,16 @@ namespace sp {
 
     private:
         void SyncFromECS();
-        void Shutdown();
+        void Shutdown(bool waitForExit);
+
+        size_t sampleRate;
+        size_t framesPerBuffer = 1024; // updated later depending on sample rate and desired latency
 
         SoundIo *soundio = nullptr;
         int deviceIndex;
         SoundIoDevice *device = nullptr;
         SoundIoOutStream *outstream = nullptr;
         std::unique_ptr<vraudio::ResonanceAudioApi> resonance;
-        size_t framesPerBuffer = 1024; // updated later depending on sample rate and desired latency
 
         nqr::NyquistIO loader;
 

--- a/src/core/core/RegisteredThread.cc
+++ b/src/core/core/RegisteredThread.cc
@@ -21,6 +21,7 @@ namespace sp {
 
     void RegisteredThread::StartThread(bool stepMode) {
         Assert(!thread.joinable(), "RegisteredThread::StartThread() called while thread already running");
+        exiting = false;
         thread = std::thread([this, stepMode] {
             tracy::SetThreadName(threadName.c_str());
             if (!ThreadInit()) return;


### PR DESCRIPTION
Also prepare for future support for restarting the output stream when the device changes