### PR TITLE
Add voxel lighting feedback from OpenGL

### DIFF
--- a/src/graphics/graphics/vulkan/render_graph/Resources.cc
+++ b/src/graphics/graphics/vulkan/render_graph/Resources.cc
@@ -23,6 +23,10 @@ namespace sp::vulkan::render_graph {
                 Assert(!images[id], "dangling render target");
                 Assert(!buffers[id], "dangling buffer");
 
+                for (auto &scope : nameScopes) {
+                    scope.ClearID(id);
+                }
+
                 freeIDs.push_back(id);
                 resources[id].type = Resource::Type::Undefined;
                 resourceNames[id] = {};
@@ -277,6 +281,19 @@ namespace sp::vulkan::render_graph {
         auto &nameID = resourceNames[name.data()];
         Assert(!nameID, "resource already registered");
         nameID = id;
+    }
+
+    void Resources::Scope::ClearID(ResourceID id) {
+        for (auto &frame : frames) {
+            auto it = frame.resourceNames.begin();
+            while (it != frame.resourceNames.end()) {
+                if (it->second == id) {
+                    frame.resourceNames.erase(it++);
+                } else {
+                    it++;
+                }
+            }
+        }
     }
 
     PooledImagePtr Resources::GetImageFromPool(const ImageDesc &desc) {

--- a/src/graphics/graphics/vulkan/render_graph/Resources.hh
+++ b/src/graphics/graphics/vulkan/render_graph/Resources.hh
@@ -138,6 +138,7 @@ namespace sp::vulkan::render_graph {
 
             ResourceID GetID(string_view name, uint32 frameIndex) const;
             void SetID(string_view name, ResourceID id, uint32 frameIndex);
+            void ClearID(ResourceID id);
         };
 
         vector<Scope> nameScopes;


### PR DESCRIPTION
I ran into an issue with referencing images from the previous frame due to the dummy Radiance image existing in the previous frame.
I resolved this by removing references from the named scope lookup once they've been freed.

This seems to resolve the issues hit by this PR as well: https://github.com/frustra/strayphotons/pull/359