### PR TITLE
Project light gel textures through optics

### DIFF
--- a/shaders/lib/shading.glsl
+++ b/shaders/lib/shading.glsl
@@ -116,6 +116,10 @@ vec3 DirectShading(vec3 worldPosition,
         uint gelId = lights[i].gelId;
         if (gelId > 0) {
             vec2 coord = ViewPosToScreenPos(shadowMapPos, lights[i].proj).xy;
+
+            vec4 cornerUVs[2] = lights[i].cornerUVs;
+            coord = bilinearMix(cornerUVs[0].xy, cornerUVs[1].zw, cornerUVs[0].zw, cornerUVs[1].xy, coord);
+
             lightTint = texture(textures[gelId], vec2(coord.x, 1 - coord.y)).rgb * float(coord == clamp(coord, 0, 1));
         }
 #endif

--- a/shaders/lib/types_common.glsl
+++ b/shaders/lib/types_common.glsl
@@ -45,6 +45,7 @@ struct Light {
     mat4 invView;
     vec4 mapOffset;
     vec4 bounds;
+    vec4 cornerUVs[2];
     vec2 clip;
 
     uint gelId;

--- a/shaders/lib/util.glsl
+++ b/shaders/lib/util.glsl
@@ -41,6 +41,12 @@ vec2 linstep(vec2 low, vec2 high, vec2 v) {
     return clamp((v - low) / (high - low), 0.0, 1.0);
 }
 
+vec2 bilinearMix(vec2 v00, vec2 v10, vec2 v01, vec2 v11, vec2 alpha) {
+    vec2 x1 = mix(v00, v10, alpha.x);
+    vec2 x2 = mix(v01, v11, alpha.x);
+    return mix(x1, x2, alpha.y);
+}
+
 #include "color_util.glsl"
 #include "spatial_util.glsl"
 

--- a/src/graphics/graphics/vulkan/render_passes/Lighting.hh
+++ b/src/graphics/graphics/vulkan/render_passes/Lighting.hh
@@ -61,6 +61,7 @@ namespace sp::vulkan::renderer {
             glm::mat4 invView;
             glm::vec4 mapOffset;
             glm::vec4 bounds;
+            std::array<glm::vec2, 4> cornerUVs; // clockwise winding starting at the bottom left
             glm::vec2 clip;
             uint32_t gelId;
             uint32_t previousIndex;
@@ -68,7 +69,7 @@ namespace sp::vulkan::renderer {
 
             float padding[3];
         };
-        static_assert(sizeof(GPULight) == 23 * 4 * sizeof(float), "GPULight size incorrect");
+        static_assert(sizeof(GPULight) == 25 * 4 * sizeof(float), "GPULight size incorrect");
 
         struct GPUData {
             GPULight lights[MAX_LIGHTS];


### PR DESCRIPTION
This is done by storing the UV coordinates of the source lighting gel for the 4 corners of each optic. The final UV is determined using bilinear interpolation of these 4 corners. It's not strictly accurate since the projection is nonlinear, but it's fast and works decently.

Test using a checkerboard gel:

![mirrortest-overhead](https://user-images.githubusercontent.com/984857/188732330-efbb816e-5c86-4ce4-aa7c-36df67577deb.png)
