### PR TITLE
Allow guis to be placed in debug gui, use for editor

### DIFF
--- a/assets/scenes/menu.json
+++ b/assets/scenes/menu.json
@@ -22,7 +22,7 @@
 				"rotate": [[-45, 0, 1, 0], [-45, 1, 0, 0]]
 			},
 			"gui": {
-				"target": "lobby"
+				"windowName": "lobby"
 			},
 			"screen": {
 				"luminance": [3, 1, 3]

--- a/src/core/ecs/ComponentMetadata.hh
+++ b/src/core/ecs/ComponentMetadata.hh
@@ -23,6 +23,7 @@ namespace ecs {
     enum class VisibilityMask;
     enum class OpticType;
     enum class InterpolationMode;
+    enum class GuiTarget;
 
     enum class FieldType {
         Bool = 0,
@@ -50,6 +51,7 @@ namespace ecs {
         InterpolationMode,
         VisibilityMask,
         OpticType,
+        GuiTarget,
         Count,
     };
 
@@ -73,7 +75,8 @@ namespace ecs {
         std::vector<AnimationState>,
         InterpolationMode,
         VisibilityMask,
-        OpticType>;
+        OpticType,
+        GuiTarget>;
 
     static_assert(std::tuple_size_v<FieldTypes> == (size_t)FieldType::Count, "ComponentMetatdata field types mismatch");
 

--- a/src/core/ecs/components/Gui.hh
+++ b/src/core/ecs/components/Gui.hh
@@ -7,14 +7,21 @@ namespace sp {
 }
 
 namespace ecs {
-    struct Gui {
-        sp::GuiContext *context = nullptr;
-        std::string target; // Must be set at component creation
-        bool disabled = false;
-
-        Gui(sp::GuiContext *context = nullptr) : context(context) {}
-        Gui(std::string targetName) : target(targetName) {}
+    enum class GuiTarget {
+        None,
+        World,
+        Debug,
     };
 
-    static Component<Gui> ComponentGui("gui", ComponentField::New("target", &Gui::target));
+    struct Gui {
+        GuiTarget target = GuiTarget::World;
+        std::string windowName; // Must be set at component creation
+
+        Gui() {}
+        Gui(std::string windowName, GuiTarget target = GuiTarget::World) : windowName(windowName), target(target) {}
+    };
+
+    static Component<Gui> ComponentGui("gui",
+        ComponentField::New("windowName", &Gui::windowName),
+        ComponentField::New("target", &Gui::target));
 } // namespace ecs

--- a/src/core/editor/EditorSystem.cc
+++ b/src/core/editor/EditorSystem.cc
@@ -16,14 +16,18 @@ namespace sp {
         funcs.Register(this,
             "edit",
             "Edit the specified entity, or the entity being looked at",
-            &EditorSystem::OpenEditor);
+            &EditorSystem::OpenEditorFlat);
+
+        funcs.Register(this,
+            "editinworld",
+            "Edit the specified entity, or the entity being looked at",
+            &EditorSystem::OpenEditorWorld);
 
         GetSceneManager().QueueActionAndBlock(SceneAction::ApplySystemScene,
             "editor",
             [this](ecs::Lock<ecs::AddRemove> lock, std::shared_ptr<Scene> scene) {
                 auto inspector = scene->NewSystemEntity(lock, scene, inspectorEntity.Name());
-                auto &gui = inspector.Set<ecs::Gui>(lock, "inspector");
-                gui.disabled = true;
+                inspector.Set<ecs::Gui>(lock, "inspector", ecs::GuiTarget::None);
                 inspector.Set<ecs::Screen>(lock);
                 inspector.Set<ecs::EventInput>(lock,
                     INTERACT_EVENT_INTERACT_POINT,
@@ -31,51 +35,9 @@ namespace sp {
                     EDITOR_EVENT_EDIT_TARGET);
                 inspector.Set<ecs::Physics>(lock,
                     ecs::PhysicsShape::Box(glm::vec3(1, 1, 0.01)),
-                    ecs::PhysicsGroup::UserInterface,
+                    ecs::PhysicsGroup::NoClip,
                     false /* dynamic */);
                 inspector.Set<ecs::TransformTree>(lock);
-
-                auto &script = inspector.Set<ecs::Script>(lock);
-                script.AddOnTick(ecs::EntityScope{scene, ecs::Name(scene->name, "")},
-                    [this](ecs::ScriptState &state,
-                        ecs::Lock<ecs::WriteAll> lock,
-                        ecs::Entity ent,
-                        chrono_clock::duration interval) {
-                        if (!ent.Has<ecs::TransformTree, ecs::Gui>(lock)) return;
-
-                        auto &transform = ent.Get<ecs::TransformTree>(lock);
-                        auto &gui = ent.Get<ecs::Gui>(lock);
-
-                        auto player = playerEntity.Get(lock);
-                        if (!player.Has<ecs::TransformSnapshot>(lock)) return;
-
-                        auto target = targetEntity.Get(lock);
-                        if (!target.Exists(lock)) {
-                            gui.disabled = true;
-                            previousTargetEntity = {};
-                            return;
-                        } else if (target == previousTargetEntity) {
-                            return;
-                        }
-
-                        previousTargetEntity = target;
-                        gui.disabled = false;
-                        if (target.Has<ecs::TransformSnapshot>(lock)) {
-                            auto targetPos = target.Get<const ecs::TransformSnapshot>(lock).GetPosition();
-                            auto playerPos = player.Get<const ecs::TransformSnapshot>(lock).GetPosition();
-                            auto targetDir = glm::normalize(
-                                glm::vec3(targetPos.x - playerPos.x, 0, targetPos.z - playerPos.z));
-                            transform.pose.SetPosition(playerPos + targetDir * CVarEditorDistance.Get() +
-                                                       glm::vec3(0, CVarEditorOffset.Get(), 0));
-                            transform.pose.SetRotation(glm::quat(glm::vec3(glm::radians(CVarEditorAngle.Get()),
-                                glm::atan(-targetDir.x, -targetDir.z),
-                                0)));
-                            transform.parent = {};
-                        } else {
-                            transform.pose = ecs::Transform(glm::vec3(0, 1, -1));
-                            transform.parent = playerEntity;
-                        }
-                    });
             });
     }
 
@@ -83,11 +45,24 @@ namespace sp {
         GetSceneManager().QueueActionAndBlock(SceneAction::RemoveScene, "editor");
     }
 
-    void EditorSystem::OpenEditor(std::string targetName) {
-        auto lock = ecs::World.StartTransaction<ecs::ReadAll, ecs::SendEventsLock, ecs::Write<ecs::Gui>>();
+    void EditorSystem::OpenEditorFlat(std::string targetName) {
+        OpenEditor(targetName, true);
+    }
+
+    void EditorSystem::OpenEditorWorld(std::string targetName) {
+        OpenEditor(targetName, false);
+    }
+
+    void EditorSystem::OpenEditor(std::string targetName, bool flatMode) {
+        auto lock = ecs::World.StartTransaction<ecs::ReadAll,
+            ecs::SendEventsLock,
+            ecs::Write<ecs::Gui, ecs::TransformTree, ecs::Physics>>();
+
         auto inspector = inspectorEntity.Get(lock);
 
-        ecs::Entity entity;
+        if (!inspector.Has<ecs::TransformTree, ecs::Gui, ecs::Physics>(lock)) return;
+
+        ecs::Entity target;
         if (targetName.empty()) {
             auto flatview = ecs::EntityWith<ecs::Name>(lock, ecs::Name("player", "flatview"));
             if (flatview.Has<ecs::PhysicsQuery>(lock)) {
@@ -95,16 +70,52 @@ namespace sp {
                 for (auto &subQuery : query.queries) {
                     auto *raycastQuery = std::get_if<ecs::PhysicsQuery::Raycast>(&subQuery);
                     if (raycastQuery && raycastQuery->result) {
-                        entity = raycastQuery->result->target;
-                        if (entity) break;
+                        target = raycastQuery->result->target;
+                        if (target) break;
                     }
                 }
             }
         } else {
             ecs::EntityRef ref = ecs::Name(targetName, ecs::Name());
-            entity = ref.Get(lock);
+            target = ref.Get(lock);
         }
-        targetEntity = entity;
-        ecs::EventBindings::SendEvent(lock, "/edit/target", inspector, entity);
+
+        auto &gui = inspector.Get<ecs::Gui>(lock);
+        auto &physics = inspector.Get<ecs::Physics>(lock);
+
+        if (!target.Exists(lock)) {
+            gui.target = ecs::GuiTarget::None;
+            physics.group = ecs::PhysicsGroup::NoClip;
+            return;
+        }
+
+        ecs::EventBindings::SendEvent(lock, "/edit/target", inspector, target);
+
+        if (flatMode) {
+            gui.target = ecs::GuiTarget::Debug;
+            physics.group = ecs::PhysicsGroup::NoClip;
+        } else {
+            gui.target = ecs::GuiTarget::World;
+            physics.group = ecs::PhysicsGroup::UserInterface;
+
+            auto &transform = inspector.Get<ecs::TransformTree>(lock);
+
+            auto player = playerEntity.Get(lock);
+            if (!player.Has<ecs::TransformSnapshot>(lock)) return;
+
+            if (target.Has<ecs::TransformSnapshot>(lock)) {
+                auto targetPos = target.Get<const ecs::TransformSnapshot>(lock).GetPosition();
+                auto playerPos = player.Get<const ecs::TransformSnapshot>(lock).GetPosition();
+                auto targetDir = glm::normalize(glm::vec3(targetPos.x - playerPos.x, 0, targetPos.z - playerPos.z));
+                transform.pose.SetPosition(
+                    playerPos + targetDir * CVarEditorDistance.Get() + glm::vec3(0, CVarEditorOffset.Get(), 0));
+                transform.pose.SetRotation(glm::quat(
+                    glm::vec3(glm::radians(CVarEditorAngle.Get()), glm::atan(-targetDir.x, -targetDir.z), 0)));
+                transform.parent = {};
+            } else {
+                transform.pose = ecs::Transform(glm::vec3(0, 1, -1));
+                transform.parent = playerEntity;
+            }
+        }
     }
 } // namespace sp

--- a/src/core/editor/EditorSystem.hh
+++ b/src/core/editor/EditorSystem.hh
@@ -4,16 +4,18 @@
 #include "ecs/Ecs.hh"
 
 namespace sp {
+
     class EditorSystem {
     public:
         EditorSystem();
         ~EditorSystem();
 
-        void OpenEditor(std::string targetName);
+        void OpenEditorFlat(std::string targetName);
+        void OpenEditorWorld(std::string targetName);
 
     private:
-        ecs::EntityRef targetEntity;
-        ecs::Entity previousTargetEntity = {};
+        void OpenEditor(std::string targetName, bool flatMode);
+
         ecs::EntityRef playerEntity = ecs::Name("player", "player");
         ecs::EntityRef inspectorEntity = ecs::Name("editor", "inspector");
 

--- a/src/graphics/GraphicsManager.cc
+++ b/src/graphics/GraphicsManager.cc
@@ -156,6 +156,8 @@ namespace sp {
 
     #if defined(SP_GRAPHICS_SUPPORT_GL)
         renderer->PrepareGuis(game->debugGui.get(), game->menuGui.get());
+    #elif defined(SP_GRAPHICS_SUPPORT_VK)
+        renderer->SetMenuGui(game->menuGui.get());
     #endif
 
         if (game->debugGui) game->debugGui->BeforeFrame();

--- a/src/graphics/graphics/gui/DebugGuiManager.hh
+++ b/src/graphics/graphics/gui/DebugGuiManager.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "ecs/Ecs.hh"
 #include "graphics/gui/SystemGuiManager.hh"
 
 namespace sp {
@@ -14,6 +15,15 @@ namespace sp {
         void DefineWindows() override;
 
     private:
+        void AddGui(ecs::Entity ent, const ecs::Gui &gui);
+
         bool consoleOpen = false;
+        ecs::ComponentObserver<ecs::Gui> guiObserver;
+
+        struct GuiEntityContext {
+            ecs::Entity entity;
+            shared_ptr<GuiWindow> window = nullptr;
+        };
+        vector<GuiEntityContext> guis;
     };
 } // namespace sp

--- a/src/graphics/graphics/gui/GuiContext.cc
+++ b/src/graphics/graphics/gui/GuiContext.cc
@@ -19,16 +19,6 @@ namespace sp {
         return fontList;
     }
 
-    void GuiWindow::Add() {
-        ImGui::SetNextWindowPos(ImVec2(0.0f, 0.0f));
-        ImGui::SetNextWindowSize(ImGui::GetIO().DisplaySize);
-        ImGui::Begin(name.c_str(),
-            nullptr,
-            ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse);
-        DefineContents();
-        ImGui::End();
-    }
-
     GuiContext::GuiContext(const std::string &name) : name(name) {
         imCtx = ImGui::CreateContext();
 
@@ -70,17 +60,16 @@ namespace sp {
         SetGuiContext();
     }
 
-    void GuiContext::DefineWindows() {
-        for (auto &component : components) {
-            component->Add();
-        }
-    }
-
     void GuiContext::Attach(const std::shared_ptr<GuiRenderable> &component) {
         components.emplace_back(component);
     }
 
-    bool CreateGuiWindow(GuiContext *context, const string &windowName) {
+    void GuiContext::Detach(const std::shared_ptr<GuiRenderable> &component) {
+        auto it = std::find(components.begin(), components.end(), component);
+        if (it != components.end()) components.erase(it);
+    }
+
+    shared_ptr<GuiWindow> CreateGuiWindow(GuiContext *context, const string &windowName) {
         shared_ptr<GuiWindow> window;
         if (windowName == "lobby") {
             window = make_shared<LobbyGui>(windowName);
@@ -88,10 +77,10 @@ namespace sp {
             window = make_shared<InspectorGui>(windowName);
         } else {
             Errorf("unknown gui window: %s", windowName);
-            return false;
+            return nullptr;
         }
         context->Attach(window);
-        return true;
+        return window;
     }
 
     static void pushFont(Font fontType, float fontSize) {

--- a/src/graphics/graphics/gui/GuiContext.hh
+++ b/src/graphics/graphics/gui/GuiContext.hh
@@ -24,19 +24,17 @@ namespace sp {
 
     class GuiRenderable {
     public:
-        virtual void Add() = 0;
+        GuiRenderable(const string &name) : name(name) {}
+
+        const string name;
+        virtual void DefineContents() = 0;
 
         void PushFont(Font fontType, float fontSize);
     };
 
     class GuiWindow : public GuiRenderable {
     public:
-        const string name;
-
-        GuiWindow(const string &name) : name(name) {}
-        virtual void DefineContents() = 0;
-
-        virtual void Add();
+        GuiWindow(const string &name) : GuiRenderable(name) {}
     };
 
     class GuiContext {
@@ -44,10 +42,11 @@ namespace sp {
         GuiContext(const std::string &name);
         virtual ~GuiContext();
         void Attach(const std::shared_ptr<GuiRenderable> &component);
+        void Detach(const std::shared_ptr<GuiRenderable> &component);
         void SetGuiContext();
 
         virtual void BeforeFrame();
-        virtual void DefineWindows();
+        virtual void DefineWindows() = 0;
 
         const std::string &Name() const {
             return name;
@@ -55,13 +54,15 @@ namespace sp {
 
         void PushFont(Font fontType, float fontSize);
 
-    private:
+    protected:
         std::vector<std::shared_ptr<GuiRenderable>> components;
+
+    private:
         ImGuiContext *imCtx = nullptr;
         std::string name;
     };
 
-    bool CreateGuiWindow(GuiContext *context, const string &name);
+    shared_ptr<GuiWindow> CreateGuiWindow(GuiContext *context, const string &name);
 
     std::span<FontDef> GetFontList();
 } // namespace sp

--- a/src/graphics/graphics/gui/SystemGuiManager.cc
+++ b/src/graphics/graphics/gui/SystemGuiManager.cc
@@ -21,7 +21,6 @@ namespace sp {
                 auto ent = scene->NewSystemEntity(lock, scene, guiEntity.Name());
                 ent.Set<ecs::FocusLayer>(lock, layer);
                 ent.Set<ecs::EventInput>(lock, INPUT_EVENT_MENU_SCROLL, INPUT_EVENT_MENU_TEXT_INPUT);
-                ent.Set<ecs::Gui>(lock, this);
 
                 auto &signalBindings = ent.Set<ecs::SignalBindings>(lock);
                 signalBindings.Bind(INPUT_SIGNAL_MENU_PRIMARY_TRIGGER, playerEntity, INPUT_SIGNAL_MENU_PRIMARY_TRIGGER);

--- a/src/graphics/graphics/gui/WorldGuiManager.cc
+++ b/src/graphics/graphics/gui/WorldGuiManager.cc
@@ -13,6 +13,18 @@ namespace sp {
     WorldGuiManager::WorldGuiManager(ecs::Entity guiEntity, const std::string &name)
         : GuiContext(name), guiEntity(guiEntity) {}
 
+    void WorldGuiManager::DefineWindows() {
+        for (auto &window : components) {
+            ImGui::SetNextWindowPos(ImVec2(0.0f, 0.0f));
+            ImGui::SetNextWindowSize(ImGui::GetIO().DisplaySize);
+            ImGui::Begin(window->name.c_str(),
+                nullptr,
+                ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse);
+            window->DefineContents();
+            ImGui::End();
+        }
+    }
+
     void WorldGuiManager::BeforeFrame() {
         ZoneScoped;
         GuiContext::BeforeFrame();

--- a/src/graphics/graphics/gui/WorldGuiManager.hh
+++ b/src/graphics/graphics/gui/WorldGuiManager.hh
@@ -9,6 +9,7 @@ namespace sp {
         WorldGuiManager(ecs::Entity guiEntity, const std::string &name);
 
         virtual void BeforeFrame();
+        void DefineWindows() override;
 
     private:
         ecs::EntityRef guiEntity;

--- a/src/graphics/graphics/vulkan/Renderer.hh
+++ b/src/graphics/graphics/vulkan/Renderer.hh
@@ -43,6 +43,7 @@ namespace sp::vulkan {
         void EndFrame();
 
         void SetDebugGui(GuiContext &gui);
+        void SetMenuGui(GuiContext *gui);
 
 #ifdef SP_XR_SUPPORT
         void SetXRSystem(shared_ptr<xr::XrSystem> xr) {
@@ -64,7 +65,8 @@ namespace sp::vulkan {
 #endif
 
         void AddGui(ecs::Entity ent, const ecs::Gui &gui);
-        void AddGuis(ecs::Lock<ecs::Read<ecs::TransformSnapshot, ecs::Gui, ecs::Screen>> lock);
+        void AddWorldGuis(ecs::Lock<ecs::Read<ecs::TransformSnapshot, ecs::Gui, ecs::Screen>> lock);
+        void AddMenuGui(ecs::Lock<ecs::Read<ecs::View>> lock);
         void AddDeferredPasses(ecs::Lock<ecs::Read<ecs::TransformSnapshot, ecs::Screen, ecs::Gui, ecs::LaserLine>> lock,
             const ecs::View &view,
             chrono_clock::duration elapsedTime);
@@ -90,7 +92,7 @@ namespace sp::vulkan {
             rg::ResourceID renderGraphID = rg::InvalidResource;
         };
         vector<RenderableGui> guis;
-        GuiContext *debugGui = nullptr;
+        GuiContext *debugGui = nullptr, *menuGui = nullptr;
 
         ecs::ComponentObserver<ecs::Gui> guiObserver;
 

--- a/src/graphics/graphics/vulkan/gui/ProfilerGui.hh
+++ b/src/graphics/graphics/vulkan/gui/ProfilerGui.hh
@@ -15,7 +15,7 @@ namespace sp::vulkan {
             GPU,
         };
 
-        ProfilerGui(PerfTimer &timer) : timer(timer), msWindowSize(1000) {}
+        ProfilerGui(PerfTimer &timer) : GuiRenderable("profiler"), timer(timer), msWindowSize(1000) {}
         virtual ~ProfilerGui() {}
 
         static float GetHistogramValue(void *data, int index) {
@@ -23,7 +23,7 @@ namespace sp::vulkan {
             return (float)self->drawHistogram.buckets[index];
         }
 
-        void Add() {
+        void DefineContents() {
             if (timer.lastCompleteFrame.empty()) return;
             if (!CVarProfileRender.Get()) return;
 

--- a/src/graphics/graphics/vulkan/render_passes/Emissive.cc
+++ b/src/graphics/graphics/vulkan/render_passes/Emissive.cc
@@ -62,11 +62,15 @@ namespace sp::vulkan::renderer {
                     auto &screenComp = ent.Get<ecs::Screen>(lock);
 
                     string textureName;
-                    if (screenComp.textureName.empty() && ent.Has<ecs::Gui>(lock)) {
+                    if (!screenComp.textureName.empty()) {
+                        textureName = screenComp.textureName;
+                    } else if (ent.Has<ecs::Gui>(lock)) {
                         auto &gui = ent.Get<ecs::Gui>(lock);
-                        if (!gui.target.empty() && !gui.disabled) textureName = gui.target + "_gui";
+                        if (gui.windowName.empty() || gui.target != ecs::GuiTarget::World) continue;
+                        textureName = gui.windowName + "_gui";
+                    } else {
+                        continue;
                     }
-                    if (textureName.empty()) textureName = screenComp.textureName;
 
                     if (builder.GetID(textureName, false) == InvalidResource) continue;
 

--- a/src/main/Game.cc
+++ b/src/main/Game.cc
@@ -81,7 +81,6 @@ namespace sp {
             debugGui = std::make_unique<DebugGuiManager>();
             graphics.Init();
 
-            // must create all gui instances after initializing graphics, except for the special debug gui
             menuGui = std::make_unique<MenuGuiManager>(this->graphics);
         }
 #endif


### PR DESCRIPTION
`edit` command opens the editor in the debug gui
`editinworld` opens the editor in a world gui pane

The world gui editor is set to noclip when not in use.

Needs some work to have a way to capture/release the mouse without making the console pop over the editor.