### PR TITLE
Add fiber optic example without fiber connection (in blackhole2)

### DIFF
--- a/assets/scenes/blackhole2.json
+++ b/assets/scenes/blackhole2.json
@@ -94,6 +94,150 @@
 					"speed": 1.5
 				}
 			}
+		},
+		{
+			"name": "table",
+			"transform": {
+			},
+			"script": {
+				"prefab": "template",
+				"parameters": {
+					"source": "table"
+				}
+			}
+		},
+		{
+			"name": "mirrorcube1",
+			"transform": {
+				"translate": [0.4, 0.89, 0.14],
+				"rotate": [160, 0, 1, 0],
+				"scale": 0.1
+			},
+			"script": {
+				"prefab": "template",
+				"parameters": { "source": "mirrorcube" }
+			}
+		},
+		{
+			"name": "mirrorcube1.mirrorcube",
+			"physics": {
+				"model": "box",
+				"density": 10
+			}
+		},
+		{
+			"name": "laser_mount_1",
+			"transform": {
+				"translate": [0.14, 0.86, 0.14],
+				"rotate": [-90, 0, 1, 0]
+			},
+			"script": {
+				"prefab": "gltf",
+				"parameters": {
+					"model": "laser-plug-mount",
+					"render": true
+				}
+			}
+		},
+		{
+			"name": "laser_plug_1",
+			"transform": {
+				"parent": "laser_mount_1.round-fitting-mount"
+			},
+			"script": {
+				"prefab": "gltf",
+				"parameters": {
+					"model": "laser-plug",
+					"render": true
+				}
+			},
+			"laser_line": {},
+			"laser_emitter": {
+				"color": [1, 0, 0]
+			}
+		},
+		{
+			"name": "laser_fiber_1_socket_mount",
+			"transform": {
+				"translate": [0.86, 0.86, 0.14],
+				"rotate": [-90, 0, 1, 0]
+			},
+			"script": {
+				"prefab": "gltf",
+				"parameters": {
+					"model": "laser-plug-mount",
+					"render": true
+				}
+			}
+		},
+		{
+			"name": "laser_fiber_1_socket",
+			"transform": {
+				"parent": "laser_fiber_1_socket_mount",
+				"translate": [0, 0, 0.025]
+			},
+			"script": {
+				"prefab": "gltf",
+				"parameters": {
+					"model": "laser-socket",
+					"render": true
+				}
+			}
+		},
+		{
+			"name": "laser_fiber_1_sensor",
+			"transform": {
+				"parent": "laser_fiber_1_socket",
+				"translate": [0, 0, -0.03],
+				"scale": 0.05
+			},
+			"script": {
+				"prefab": "gltf",
+				"parameters": {
+					"model": "sensor",
+					"render": true,
+					"physics": "static"
+				}
+			}
+		},
+		{
+			"name": "laser_fiber_1_sensor.Icosphere",
+			"signal_output": {},
+			"laser_sensor": {
+				"threshold": [1, 0, 0]
+			}
+		},
+		{
+			"name": "laser_fiber_1_output_mount",
+			"transform": {
+				"translate": [0.86, 0.86, 0.28],
+				"rotate": [90, 0, 1, 0]
+			},
+			"script": {
+				"prefab": "gltf",
+				"parameters": {
+					"model": "laser-plug-mount",
+					"render": true
+				}
+			}
+		},
+		{
+			"name": "laser_fiber_1_output",
+			"transform": {
+				"parent": "laser_fiber_1_output_mount.round-fitting-mount"
+			},
+			"script": {
+				"prefab": "gltf",
+				"parameters": {
+					"model": "laser-plug",
+					"render": true
+				}
+			},
+			"signal_bindings": {
+				"laser_color_r": "laser_fiber_1_sensor.Icosphere/light_value_r"
+			},
+			"laser_line": {},
+			"laser_emitter": {}
 		}
 	]
 }

--- a/src/core/core/Common.hh
+++ b/src/core/core/Common.hh
@@ -114,6 +114,11 @@ namespace sp {
             return *this;
         }
 
+        color_t &operator+=(const color_t &other) {
+            color += other.color;
+            return *this;
+        }
+
         bool operator==(const color_t &other) const {
             return color == other.color;
         }

--- a/src/core/ecs/components/LaserEmitter.hh
+++ b/src/core/ecs/components/LaserEmitter.hh
@@ -8,8 +8,8 @@
 
 namespace ecs {
     struct LaserEmitter {
-        float intensity = 1.0f; // multiplier applied to color
-        sp::color_t color = glm::vec3(1); // HDR value
+        float intensity = 1.0f; // multiplier applied to color to produce the final luminance
+        sp::color_t color = glm::vec3(0); // HDR value, added to laser_color_* signal
         bool on = true;
     };
 

--- a/src/physx/physx/LaserSystem.cc
+++ b/src/physx/physx/LaserSystem.cc
@@ -49,7 +49,8 @@ namespace sp {
         color_t color;
     };
 
-    void LaserSystem::Frame(ecs::Lock<ecs::Read<ecs::TransformSnapshot, ecs::LaserEmitter, ecs::OpticalElement>,
+    void LaserSystem::Frame(ecs::Lock<ecs::ReadSignalsLock,
+        ecs::Read<ecs::TransformSnapshot, ecs::LaserEmitter, ecs::OpticalElement>,
         ecs::Write<ecs::LaserLine, ecs::LaserSensor, ecs::SignalOutput>> lock) {
         ZoneScoped;
 
@@ -74,6 +75,14 @@ namespace sp {
             auto &segments = std::get<ecs::LaserLine::Segments>(lines.line);
             segments.clear();
             color_t color = emitter.color;
+
+            color_t signalColor = glm::vec3{
+                ecs::SignalBindings::GetSignal(lock, entity, "laser_color_r"),
+                ecs::SignalBindings::GetSignal(lock, entity, "laser_color_g"),
+                ecs::SignalBindings::GetSignal(lock, entity, "laser_color_b"),
+            };
+
+            color += signalColor;
 
             glm::vec3 rayStart = transform.GetPosition();
             glm::vec3 rayDir = transform.GetForward();

--- a/src/physx/physx/LaserSystem.hh
+++ b/src/physx/physx/LaserSystem.hh
@@ -10,7 +10,8 @@ namespace sp {
         LaserSystem(PhysxManager &manager);
         ~LaserSystem() {}
 
-        void Frame(ecs::Lock<ecs::Read<ecs::TransformSnapshot, ecs::LaserEmitter, ecs::OpticalElement>,
+        void Frame(ecs::Lock<ecs::ReadSignalsLock,
+            ecs::Read<ecs::TransformSnapshot, ecs::LaserEmitter, ecs::OpticalElement>,
             ecs::Write<ecs::LaserLine, ecs::LaserSensor, ecs::SignalOutput>> lock);
 
     private:


### PR DESCRIPTION
Fiber optics are implemented by chaining a light sensor to a laser emitter, using the laser_color_* signals.