### PR TITLE
Fix VR rendering and crash issues

### DIFF
--- a/src/core/ecs/components/Renderable.cc
+++ b/src/core/ecs/components/Renderable.cc
@@ -19,6 +19,7 @@ namespace ecs {
     template<>
     void Component<Renderable>::Apply(Renderable &dst, const Renderable &src, bool liveTarget) {
         if (!dst.model && src.model) dst.model = src.model;
+        if (dst.joints.empty()) dst.joints = src.joints;
     }
 
     Renderable::Renderable(const std::string &modelName, size_t meshIndex)

--- a/src/core/ecs/components/View.cc
+++ b/src/core/ecs/components/View.cc
@@ -10,14 +10,13 @@
 
 namespace ecs {
     template<>
-    bool StructMetadata::Load<View>(const EntityScope &scope, View &view, const picojson::value &src) {
-        view.UpdateProjectionMatrix();
-        return true;
-    }
-
-    template<>
     void Component<View>::Apply(View &dst, const View &src, bool liveTarget) {
-        dst.UpdateProjectionMatrix();
+        if (src.projMat != glm::identity<glm::mat4>()) {
+            dst.projMat = src.projMat;
+            dst.invProjMat = src.invProjMat;
+        } else {
+            dst.UpdateProjectionMatrix();
+        }
     }
 
     void View::UpdateProjectionMatrix() {

--- a/src/core/ecs/components/View.hh
+++ b/src/core/ecs/components/View.hh
@@ -61,7 +61,5 @@ namespace ecs {
     static Component<View> ComponentView("view", MetadataView);
 
     template<>
-    bool StructMetadata::Load<View>(const EntityScope &scope, View &dst, const picojson::value &src);
-    template<>
     void Component<View>::Apply(View &dst, const View &src, bool liveTarget);
 } // namespace ecs

--- a/src/xr/xr/openvr/InputBindings.cc
+++ b/src/xr/xr/openvr/InputBindings.cc
@@ -451,6 +451,7 @@ namespace sp::xr {
                         for (auto &action : actionSet.actions) {
                             if (action.type == Action::DataType::Skeleton) {
                                 for (auto &boneEnt : action.boneEntities) {
+                                    if (scene->GetStagingEntity(boneEnt.Name())) continue;
                                     auto ent = scene->NewSystemEntity(lock, scene, boneEnt.Name());
                                     ent.Set<ecs::TransformTree>(lock);
                                     ent.Set<ecs::SignalOutput>(lock);

--- a/src/xr/xr/openvr/OpenVrSystem.cc
+++ b/src/xr/xr/openvr/OpenVrSystem.cc
@@ -213,14 +213,14 @@ namespace sp::xr {
             auto lock = ecs::StartTransaction<ecs::Read<ecs::Name>, ecs::Write<ecs::TransformTree>>();
 
             for (auto entityRef : trackedDevices) {
-                if (entityRef != nullptr && !entityRef->Get(lock).Exists(lock)) {
+                if (entityRef && !entityRef->Get(lock).Exists(lock)) {
                     missingEntities = true;
                     break;
                 }
             }
 
             for (vr::TrackedDeviceIndex_t i = 0; i < vr::k_unMaxTrackedDeviceCount; i++) {
-                if (trackedDevices[i] != nullptr) {
+                if (trackedDevices[i]) {
                     ecs::Entity ent = trackedDevices[i]->Get(lock);
                     if (ent.Has<ecs::TransformTree>(lock) && trackedDevicePoses[i].bPoseIsValid) {
                         auto &transform = ent.Get<ecs::TransformTree>(lock);
@@ -236,8 +236,8 @@ namespace sp::xr {
             GetSceneManager().QueueActionAndBlock(SceneAction::ApplySystemScene,
                 "vr_system",
                 [this](ecs::Lock<ecs::AddRemove> lock, std::shared_ptr<Scene> scene) {
-                    for (auto entityRef : trackedDevices) {
-                        if (entityRef != nullptr && !entityRef->Get(lock).Exists(lock)) {
+                    for (auto *entityRef : trackedDevices) {
+                        if (entityRef && !scene->GetStagingEntity(entityRef->Name())) {
                             auto ent = scene->NewSystemEntity(lock, scene, entityRef->Name());
                             ent.Set<ecs::TransformTree>(lock);
                             ent.Set<ecs::EventBindings>(lock);


### PR DESCRIPTION
- Fixes View not preserving projMat from staging ECS (when set by OpenVR)
- Fixes Renderable joints not being set correctly
- Fixes OpenVR crash when controllers spawn in due to duplicate entities