### PR TITLE
Change window input events to reduce keyboard/mouse latency

### DIFF
--- a/src/game/game/GameLogic.cc
+++ b/src/game/game/GameLogic.cc
@@ -4,9 +4,11 @@
 #include "core/Tracing.hh"
 #include "ecs/EcsImpl.hh"
 #include "ecs/ScriptManager.hh"
+#include "input/BindingNames.hh"
 
 namespace sp {
-    GameLogic::GameLogic(bool stepMode) : RegisteredThread("GameLogic", 120.0, true), stepMode(stepMode) {
+    GameLogic::GameLogic(ecs::EventQueue &windowInputQueue, bool stepMode)
+        : RegisteredThread("GameLogic", 120.0, true), windowInputQueue(windowInputQueue), stepMode(stepMode) {
         if (stepMode) {
             funcs.Register<unsigned int>("steplogic",
                 "Advance the game logic by N frames, default is 1",
@@ -20,10 +22,79 @@ namespace sp {
         RegisteredThread::StartThread(stepMode);
     }
 
+    void GameLogic::UpdateInputEvents(const ecs::Lock<ecs::SendEventsLock, ecs::Write<ecs::Signals>> &lock,
+        ecs::EventQueue &inputQueue) {
+        static const ecs::EntityRef keyboardEntity = ecs::Name("input", "keyboard");
+        static const ecs::EntityRef mouseEntity = ecs::Name("input", "mouse");
+
+        static glm::vec2 prevMousePos = {};
+
+        auto keyboard = keyboardEntity.Get(lock);
+        auto mouse = mouseEntity.Get(lock);
+
+        ecs::Event event;
+        while (inputQueue.Poll(event, lock.GetTransactionId())) {
+            if (event.source == keyboard) {
+                ecs::EventBindings::SendEvent(lock, keyboardEntity, event);
+            } else if (event.source == mouse) {
+                ecs::EventBindings::SendEvent(lock, mouseEntity, event);
+            }
+
+            if (event.name == INPUT_EVENT_KEYBOARD_KEY_DOWN) {
+                auto &keyName = std::get<std::string>(event.data);
+                std::string eventName = INPUT_EVENT_KEYBOARD_KEY_BASE + keyName;
+                ecs::EventBindings::SendEvent(lock, keyboardEntity, ecs::Event{eventName, keyboard, true});
+
+                ecs::SignalRef signalRef(keyboard, INPUT_SIGNAL_KEYBOARD_KEY_BASE + keyName);
+                signalRef.SetValue(lock, 1.0);
+            } else if (event.name == INPUT_EVENT_KEYBOARD_KEY_UP) {
+                auto &keyName = std::get<std::string>(event.data);
+                std::string eventName = INPUT_EVENT_KEYBOARD_KEY_BASE + keyName;
+                ecs::EventBindings::SendEvent(lock, keyboardEntity, ecs::Event{eventName, keyboard, false});
+
+                ecs::SignalRef signalRef(keyboard, INPUT_SIGNAL_KEYBOARD_KEY_BASE + keyName);
+                signalRef.ClearValue(lock);
+            } else if (event.name == INPUT_EVENT_MOUSE_POSITION) {
+                auto &mousePos = std::get<glm::vec2>(event.data);
+                ecs::EventBindings::SendEvent(lock,
+                    mouseEntity,
+                    ecs::Event{INPUT_EVENT_MOUSE_MOVE, mouse, mousePos - prevMousePos});
+                prevMousePos = mousePos;
+
+                ecs::SignalRef refX(mouse, INPUT_SIGNAL_MOUSE_CURSOR_X);
+                ecs::SignalRef refY(mouse, INPUT_SIGNAL_MOUSE_CURSOR_Y);
+                refX.SetValue(lock, mousePos.x);
+                refY.SetValue(lock, mousePos.y);
+            } else if (event.name == INPUT_EVENT_MOUSE_LEFT_CLICK) {
+                ecs::SignalRef signalRef(mouse, INPUT_SIGNAL_MOUSE_BUTTON_LEFT);
+                if (std::get<bool>(event.data)) {
+                    signalRef.SetValue(lock, 1.0);
+                } else {
+                    signalRef.ClearValue(lock);
+                }
+            } else if (event.name == INPUT_EVENT_MOUSE_MIDDLE_CLICK) {
+                ecs::SignalRef signalRef(mouse, INPUT_SIGNAL_MOUSE_BUTTON_MIDDLE);
+                if (std::get<bool>(event.data)) {
+                    signalRef.SetValue(lock, 1.0);
+                } else {
+                    signalRef.ClearValue(lock);
+                }
+            } else if (event.name == INPUT_EVENT_MOUSE_RIGHT_CLICK) {
+                ecs::SignalRef signalRef(mouse, INPUT_SIGNAL_MOUSE_BUTTON_RIGHT);
+                if (std::get<bool>(event.data)) {
+                    signalRef.SetValue(lock, 1.0);
+                } else {
+                    signalRef.ClearValue(lock);
+                }
+            }
+        }
+    }
+
     void GameLogic::Frame() {
         ZoneScoped;
         {
             auto lock = ecs::StartTransaction<ecs::WriteAll>();
+            UpdateInputEvents(lock, windowInputQueue);
             ecs::GetScriptManager().RunOnTick(lock, interval);
         }
     }

--- a/src/game/game/GameLogic.hh
+++ b/src/game/game/GameLogic.hh
@@ -2,18 +2,29 @@
 
 #include "console/CFunc.hh"
 #include "core/RegisteredThread.hh"
+#include "ecs/Ecs.hh"
 #include "ecs/EntityRef.hh"
+#include "ecs/components/Events.hh"
+
+namespace ecs {
+    class EventQueue;
+}
 
 namespace sp {
 
     class GameLogic : public RegisteredThread {
     public:
-        GameLogic(bool stepMode);
+        GameLogic(ecs::EventQueue &windowInputQueue, bool stepMode);
 
         void StartThread();
 
+        static void UpdateInputEvents(const ecs::Lock<ecs::SendEventsLock, ecs::Write<ecs::Signals>> &lock,
+            ecs::EventQueue &inputQueue);
+
     private:
         void Frame() override;
+
+        ecs::EventQueue &windowInputQueue;
 
         bool stepMode;
         CFuncCollection funcs;

--- a/src/graphics/GraphicsManager.cc
+++ b/src/graphics/GraphicsManager.cc
@@ -65,7 +65,7 @@ namespace sp {
         context.reset(vkContext);
 
         GLFWwindow *window = vkContext->GetWindow();
-        if (window != nullptr) glfwInputHandler = make_unique<GlfwInputHandler>(*window);
+        if (window != nullptr) glfwInputHandler = make_unique<GlfwInputHandler>(game->windowEventQueue, *window);
     #endif
 
         if (game->options.count("size")) {

--- a/src/input/input/glfw/GlfwInputHandler.hh
+++ b/src/input/input/glfw/GlfwInputHandler.hh
@@ -11,7 +11,7 @@ struct GLFWwindow;
 namespace sp {
     class GlfwInputHandler {
     public:
-        GlfwInputHandler(GLFWwindow &window);
+        GlfwInputHandler(ecs::EventQueue &windowEventQueue, GLFWwindow &window);
         ~GlfwInputHandler();
 
         void Frame();
@@ -25,12 +25,10 @@ namespace sp {
         static void MouseScrollCallback(GLFWwindow *window, double xOffset, double yOffset);
 
     private:
+        ecs::EventQueue &outputEventQueue;
         GLFWwindow *window = nullptr;
 
         ecs::EntityRef keyboardEntity = ecs::Name("input", "keyboard");
         ecs::EntityRef mouseEntity = ecs::Name("input", "mouse");
-
-        ecs::EventQueue glfwEventQueue;
-        glm::vec2 prevMousePos;
     };
 } // namespace sp

--- a/src/main/Game.cc
+++ b/src/main/Game.cc
@@ -41,10 +41,10 @@ namespace sp {
     Game::Game(cxxopts::ParseResult &options, const ConsoleScript *startupScript)
         : options(options), startupScript(startupScript),
 #ifdef SP_GRAPHICS_SUPPORT
-          graphics(this, startupScript != nullptr),
+          graphics(this, startupScript != nullptr), windowEventQueue(ecs::EventQueue::MAX_QUEUE_SIZE),
 #endif
 #ifdef SP_PHYSICS_SUPPORT_PHYSX
-          physics(startupScript != nullptr),
+          physics(windowEventQueue, startupScript != nullptr),
 #endif
 #ifdef SP_XR_SUPPORT
           xr(this),
@@ -52,7 +52,7 @@ namespace sp {
 #ifdef SP_AUDIO_SUPPORT
           audio(new AudioManager),
 #endif
-          logic(startupScript != nullptr) {
+          logic(windowEventQueue, startupScript != nullptr) {
     }
 
     const int64 MaxInputPollRate = 144;

--- a/src/main/Game.hh
+++ b/src/main/Game.hh
@@ -64,6 +64,8 @@ namespace sp {
         std::atomic_uint64_t graphicsStepCount, graphicsMaxStepCount;
         GraphicsManager graphics;
 
+        ecs::EventQueue windowEventQueue;
+
         std::unique_ptr<DebugGuiManager> debugGui = nullptr;
         std::unique_ptr<MenuGuiManager> menuGui = nullptr;
 #endif

--- a/src/physx/physx/PhysxManager.cc
+++ b/src/physx/physx/PhysxManager.cc
@@ -12,6 +12,7 @@
 #include "core/Tracing.hh"
 #include "ecs/EcsImpl.hh"
 #include "ecs/ScriptManager.hh"
+#include "game/GameLogic.hh"
 #include "game/Scene.hh"
 #include "game/SceneManager.hh"
 #include "physx/ForceConstraint.hh"
@@ -29,10 +30,10 @@ namespace sp {
     CVar<bool> CVarPhysxDebugCollision("x.DebugColliders", false, "Show physx colliders");
     CVar<bool> CVarPhysxDebugJoints("x.DebugJoints", false, "Show physx joints");
 
-    PhysxManager::PhysxManager(bool stepMode)
-        : RegisteredThread("PhysX", 120.0, true), scenes(GetSceneManager()), characterControlSystem(*this),
-          constraintSystem(*this), physicsQuerySystem(*this), laserSystem(*this), animationSystem(*this),
-          workQueue("PhysXHullLoading") {
+    PhysxManager::PhysxManager(ecs::EventQueue &windowInputQueue, bool stepMode)
+        : RegisteredThread("PhysX", 120.0, true), windowInputQueue(windowInputQueue), scenes(GetSceneManager()),
+          characterControlSystem(*this), constraintSystem(*this), physicsQuerySystem(*this), laserSystem(*this),
+          animationSystem(*this), workQueue("PhysXHullLoading") {
         Logf("PhysX %d.%d.%d starting up",
             PX_PHYSICS_VERSION_MAJOR,
             PX_PHYSICS_VERSION_MINOR,
@@ -202,6 +203,8 @@ namespace sp {
                     ecs::LaserSensor,
                     ecs::Signals>,
                 ecs::PhysicsUpdateLock>();
+
+            GameLogic::UpdateInputEvents(lock, windowInputQueue);
 
             characterControlSystem.Frame(lock);
 

--- a/src/physx/physx/PhysxManager.hh
+++ b/src/physx/physx/PhysxManager.hh
@@ -99,7 +99,7 @@ namespace sp {
 
     class PhysxManager : public RegisteredThread {
     public:
-        PhysxManager(bool stepMode);
+        PhysxManager(ecs::EventQueue &windowInputQueue, bool stepMode);
         virtual ~PhysxManager() override;
 
     private:
@@ -133,6 +133,8 @@ namespace sp {
         std::atomic_bool simulate = false;
         std::atomic_bool exiting = false;
         std::vector<uint8_t> scratchBlock;
+
+        ecs::EventQueue &windowInputQueue;
 
         SceneManager &scenes;
         CFuncCollection funcs;


### PR DESCRIPTION
Moves the signal/event write transaction from the main input thread to within the Physics/GameLogic update transactions.