### PR TITLE
Fix GLTF loading full mat4 orientations, add interactive flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /assets/audio
 /assets/models/**/*.glb
 /assets/models/**/*.gltf
+/assets/models/**/*.bin
 /assets/logos
 /assets/textures
 /assets/gltf-process

--- a/docs/guides/Building_a_Basic_Scene.md
+++ b/docs/guides/Building_a_Basic_Scene.md
@@ -1,6 +1,8 @@
+# Building a Basic Scene <!-- {docsify-ignore} -->
+
 In this guide, we will build a `hello_world` scene that can be loaded, containing a room with some interactive physics objects.
 
-### Creating a New Scene
+## Creating a New Scene
 
 Start by creating a new empty scene file:
 `assets/scenes/hello_world.json`
@@ -89,7 +91,7 @@ The player should spawn on a platform and be able to walk around on it.
 
 ![hello_world](https://github.com/frustra/strayphotons/assets/1594638/0b2137d3-68b3-4775-a331-5488bf95f84c)
 
-### Adding Interactive Objects
+## Adding Interactive Objects
 
 Now for a slightly more complex example, let's add a cardboard box that can be picked up by the player:
 ```json
@@ -119,7 +121,7 @@ Now for a slightly more complex example, let's add a cardboard box that can be p
 
 The default type for the `physics` component is "Dynamic", which means it will be affected by gravity and can be pushed around.
 The weight of physics objects can be defined in 2 ways: `density`, or `mass`. The default `density` is 1000 kg/m^3, which is the density of water.
-This is much too heavy for our cardboard box, and won't allow the player to lift it, so instead we can set the `mass` explicitly to 1 kg.
+This is much too heavy for our cardboard box, and won't allow the player to lift it, so instead we set the `mass` explicitly to 1 kg.
 
 The cardboard box makes use of the `interactive_object` script, that receives and handles grab events from the player.
 The `physics_joints`, `physics_query`, and `event_input` components are all required by the `interactive_object` script.
@@ -128,7 +130,7 @@ When the object receives a `/interact/grab` event, a physics joint is created be
 
 ![hello_world2](https://github.com/frustra/strayphotons/assets/1594638/0aed357e-dec9-4f8c-92f3-0ee92ab39a58)
 
-### Attaching Entities Together
+## Attaching Entities Together
 
 Entities can be attached in a couple ways:
 
@@ -184,7 +186,7 @@ Entities can be attached in a couple ways:
            "color_override": [0, 0, 1, 1]
        },
        "physics": {,
-           "type": "Dynamic"
+           "type": "Dynamic",
            "shapes": {
                "model": "box"
            }

--- a/src/core/assets/Gltf.hh
+++ b/src/core/assets/Gltf.hh
@@ -76,7 +76,7 @@ namespace sp {
                 Primitive(const tinygltf::Model &model, const tinygltf::Primitive &primitive);
 
                 DrawMode drawMode;
-                Accessor<uint32_t, uint16_t> indexBuffer;
+                Accessor<uint32_t, uint16_t, uint8_t> indexBuffer;
                 int materialIndex;
                 Accessor<glm::vec3> positionBuffer;
                 Accessor<glm::vec3> normalBuffer;

--- a/src/scripts/prefabs/GltfPrefab.cc
+++ b/src/scripts/prefabs/GltfPrefab.cc
@@ -19,6 +19,7 @@ namespace ecs {
         PhysicsGroup physicsGroup = PhysicsGroup::World;
         bool render = true;
         std::optional<ecs::PhysicsActorType> physicsType;
+        bool interactive = false;
 
         void Prefab(const ScriptState &state,
             const std::shared_ptr<sp::Scene> &scene,
@@ -95,6 +96,15 @@ namespace ecs {
                     if (physicsType) {
                         PhysicsShape::ConvexMesh mesh(modelName, *node.meshIndex);
                         newEntity.Set<Physics>(lock, mesh, physicsGroup, *physicsType);
+
+                        if (interactive) {
+                            newEntity.Set<PhysicsJoints>(lock);
+                            newEntity.Set<PhysicsQuery>(lock);
+                            newEntity.Set<EventInput>(lock);
+                            auto &scripts = newEntity.Set<Scripts>(lock);
+                            scripts.AddOnTick(prefixName, "interactive_object");
+                            GetScriptManager().RegisterEvents(lock, newEntity);
+                        }
                     }
                 }
 
@@ -112,6 +122,7 @@ namespace ecs {
         StructField::New("skip_nodes", &GltfPrefab::skipNames),
         StructField::New("physics_group", &GltfPrefab::physicsGroup),
         StructField::New("render", &GltfPrefab::render),
-        StructField::New("physics", &GltfPrefab::physicsType));
+        StructField::New("physics", &GltfPrefab::physicsType),
+        StructField::New("interactive", &GltfPrefab::interactive));
     PrefabScript<GltfPrefab> gltfPrefab("gltf", MetadataGltfPrefab);
 } // namespace ecs


### PR DESCRIPTION
The `gltf`prefab was incorrectly loading node transforms that were defined in matrix form rather than individual translate/rotate/scale.

A new `interactive` flag was also added to the `gltf` prafab to automatically make each individual physics object grab-able.