### PR TITLE
Fix voxel grid lighting flicker on complex geometry

### DIFF
--- a/rust/sp-rs-wasm/.gitignore
+++ b/rust/sp-rs-wasm/.gitignore
@@ -1,1 +1,2 @@
 target/
+flag_check.exe

--- a/rust/sp-rs-winit/.gitignore
+++ b/rust/sp-rs-winit/.gitignore
@@ -1,1 +1,2 @@
 target/
+flag_check.exe

--- a/shaders/vulkan/voxel_fill.frag
+++ b/shaders/vulkan/voxel_fill.frag
@@ -90,7 +90,7 @@ void main() {
                          smoothstep(0.0, 0.1, length(indirectDiffuse));
     }
 
-    uint bucket = min(FRAGMENT_LIST_COUNT, imageAtomicAdd(fillCounters, ivec3(inVoxelPos), 1));
+    uint bucket = min(FRAGMENT_LIST_COUNT - 1, imageAtomicAdd(fillCounters, ivec3(inVoxelPos), 1));
     uint index = atomicAdd(fragmentListMetadata[bucket].count, 1);
     if (index >= fragmentListMetadata[bucket].capacity) return;
     if (index % MipmapWorkGroupSize == 0) atomicAdd(fragmentListMetadata[bucket].cmd.x, 1);

--- a/shaders/vulkan/voxel_merge.comp
+++ b/shaders/vulkan/voxel_merge.comp
@@ -22,7 +22,7 @@ layout(std430, binding = 2) buffer VoxelFragmentListMetadata {
 };
 
 layout(std430, binding = 3) buffer VoxelFragmentList {
-    VoxelFragment fragmentLists[];
+    VoxelFragment fragmentLists[]; // Already bound at +offset
 };
 
 #include "../lib/types_common.glsl"

--- a/shaders/vulkan/voxel_merge_layer.comp
+++ b/shaders/vulkan/voxel_merge_layer.comp
@@ -31,7 +31,7 @@ layout(std430, binding = 3) buffer VoxelFragmentListMetadata {
 };
 
 layout(std430, binding = 4) buffer VoxelFragmentList {
-    VoxelFragment fragmentLists[];
+    VoxelFragment fragmentLists[]; // Already bound at +offset
 };
 
 layout(constant_id = 0) const int FRAGMENT_LIST_INDEX = 1;

--- a/shaders/vulkan/voxel_merge_layer_serial.comp
+++ b/shaders/vulkan/voxel_merge_layer_serial.comp
@@ -1,0 +1,54 @@
+/*
+ * Stray Photons - Copyright (C) 2024 Jacob Wirth
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#version 460
+
+layout(local_size_x = 1, local_size_y = 1) in;
+
+#include "../lib/types_common.glsl"
+#include "../lib/voxel_shared.glsl"
+
+layout(binding = 0) uniform VoxelStateUniform {
+    VoxelState voxelInfo;
+};
+
+layout(binding = 1) uniform LayerDataUniform {
+    vec3 layerDirection;
+    uint layerIndex;
+};
+
+layout(binding = 2, rgba16f) uniform image3D voxelLayer;
+
+layout(std430, binding = 3) buffer VoxelFragmentListMetadata {
+    uint count;
+    uint capacity;
+    uint offset;
+    VkDispatchIndirectCommand cmd;
+};
+
+layout(std430, binding = 4) buffer VoxelFragmentList {
+    VoxelFragment fragmentLists[]; // Already bound at +offset
+};
+
+layout(constant_id = 0) const int FRAGMENT_LIST_COUNT = 1;
+
+void main() {
+	for (int index = 0; index < count; index++) {
+		ivec3 position = ivec3(fragmentLists[index].position);
+		vec3 overflowRadiance = vec3(fragmentLists[index].radiance);
+		vec3 overflowNormal = mat3(voxelInfo.worldToVoxel) * vec3(fragmentLists[index].normal);
+		float alpha = max(0, dot(overflowNormal, -layerDirection));
+		overflowRadiance *= alpha;
+
+		vec4 radiance = imageLoad(voxelLayer, position);
+		radiance.a += alpha;
+		if (radiance.a > 0) {
+			radiance.rgb = mix(radiance.rgb, overflowRadiance, alpha / radiance.a);
+			imageStore(voxelLayer, position, radiance);
+		}
+	}
+}

--- a/shaders/vulkan/voxel_merge_layer_serial.comp
+++ b/shaders/vulkan/voxel_merge_layer_serial.comp
@@ -37,18 +37,18 @@ layout(std430, binding = 4) buffer VoxelFragmentList {
 layout(constant_id = 0) const int FRAGMENT_LIST_COUNT = 1;
 
 void main() {
-	for (int index = 0; index < count; index++) {
-		ivec3 position = ivec3(fragmentLists[index].position);
-		vec3 overflowRadiance = vec3(fragmentLists[index].radiance);
-		vec3 overflowNormal = mat3(voxelInfo.worldToVoxel) * vec3(fragmentLists[index].normal);
-		float alpha = max(0, dot(overflowNormal, -layerDirection));
-		overflowRadiance *= alpha;
+    for (int index = 0; index < count; index++) {
+        ivec3 position = ivec3(fragmentLists[index].position);
+        vec3 overflowRadiance = vec3(fragmentLists[index].radiance);
+        vec3 overflowNormal = mat3(voxelInfo.worldToVoxel) * vec3(fragmentLists[index].normal);
+        float alpha = max(0, dot(overflowNormal, -layerDirection));
+        overflowRadiance *= alpha;
 
-		vec4 radiance = imageLoad(voxelLayer, position);
-		radiance.a += alpha;
-		if (radiance.a > 0) {
-			radiance.rgb = mix(radiance.rgb, overflowRadiance, alpha / radiance.a);
-			imageStore(voxelLayer, position, radiance);
-		}
-	}
+        vec4 radiance = imageLoad(voxelLayer, position);
+        radiance.a += alpha;
+        if (radiance.a > 0) {
+            radiance.rgb = mix(radiance.rgb, overflowRadiance, alpha / radiance.a);
+            imageStore(voxelLayer, position, radiance);
+        }
+    }
 }

--- a/shaders/vulkan/voxel_merge_serial.comp
+++ b/shaders/vulkan/voxel_merge_serial.comp
@@ -34,17 +34,19 @@ layout(binding = 4, r32ui) uniform uimage3D fillCounters;
 layout(constant_id = 0) const int FRAGMENT_LIST_COUNT = 1;
 
 void main() {
-	for (int index = 0; index < count; index++) {
-		ivec3 position = ivec3(fragmentList[index].position);
-		vec3 overflowRadiance = vec3(fragmentList[index].radiance);
-		vec3 overflowNormal = vec3(fragmentList[index].normal);
-		vec4 existingRadiance = imageLoad(voxelRadiance, position);
-		vec4 existingNormal = imageLoad(voxelNormals, position);
+    for (int index = 0; index < count; index++) {
+        ivec3 position = ivec3(fragmentList[index].position);
+        vec3 overflowRadiance = vec3(fragmentList[index].radiance);
+        vec3 overflowNormal = vec3(fragmentList[index].normal);
+        vec4 existingRadiance = imageLoad(voxelRadiance, position);
+        vec4 existingNormal = imageLoad(voxelNormals, position);
 
-    	uint overflowCount = imageLoad(fillCounters, position).r - FRAGMENT_LIST_COUNT + 1;
-		float weight = 1.0f / (FRAGMENT_LIST_COUNT + existingRadiance.w - 1);
-		float isNotLast = 1 - step(overflowCount, existingRadiance.w - 1); // true if existingRadiance.w - 1 < overflowCount
-		imageStore(voxelRadiance, position, vec4(mix(existingRadiance.rgb, overflowRadiance, weight), isNotLast * existingRadiance.w + 1));
-		imageStore(voxelNormals, position, vec4(mix(existingNormal.rgb, overflowNormal, weight), 1));
-	}
+        uint overflowCount = imageLoad(fillCounters, position).r - FRAGMENT_LIST_COUNT + 1;
+        float weight = 1.0f / (FRAGMENT_LIST_COUNT + existingRadiance.w - 1);
+        // isNotLast = true if existingRadiance.w - 1 < overflowCount
+        float isNotLast = 1 - step(overflowCount, existingRadiance.w - 1);
+        vec3 newRadiance = mix(existingRadiance.rgb, overflowRadiance, weight);
+        imageStore(voxelRadiance, position, vec4(newRadiance, isNotLast * existingRadiance.w + 1));
+        imageStore(voxelNormals, position, vec4(mix(existingNormal.rgb, overflowNormal, weight), 1));
+    }
 }

--- a/shaders/vulkan/voxel_merge_serial.comp
+++ b/shaders/vulkan/voxel_merge_serial.comp
@@ -1,0 +1,50 @@
+/*
+ * Stray Photons - Copyright (C) 2024 Jacob Wirth
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#version 460
+
+layout(local_size_x = 1, local_size_y = 1) in;
+
+#include "../lib/voxel_shared.glsl"
+
+layout(binding = 0, rgba16f) uniform image3D voxelRadiance;
+layout(binding = 1, rgba16f) uniform image3D voxelNormals;
+
+layout(std430, binding = 2) buffer VoxelFragmentListMetadata {
+    uint count;
+    uint capacity;
+    uint offset;
+    VkDispatchIndirectCommand cmd;
+};
+
+layout(std430, binding = 3) buffer VoxelFragmentList {
+    VoxelFragment fragmentList[];
+};
+
+layout(binding = 4, r32ui) uniform uimage3D fillCounters;
+
+#include "../lib/types_common.glsl"
+#include "../lib/util.glsl"
+#include "../lib/voxel_shared.glsl"
+
+layout(constant_id = 0) const int FRAGMENT_LIST_COUNT = 1;
+
+void main() {
+	for (int index = 0; index < count; index++) {
+		ivec3 position = ivec3(fragmentList[index].position);
+		vec3 overflowRadiance = vec3(fragmentList[index].radiance);
+		vec3 overflowNormal = vec3(fragmentList[index].normal);
+		vec4 existingRadiance = imageLoad(voxelRadiance, position);
+		vec4 existingNormal = imageLoad(voxelNormals, position);
+
+    	uint overflowCount = imageLoad(fillCounters, position).r - FRAGMENT_LIST_COUNT + 1;
+		float weight = 1.0f / (FRAGMENT_LIST_COUNT + existingRadiance.w - 1);
+		float isNotLast = 1 - step(overflowCount, existingRadiance.w - 1); // true if existingRadiance.w - 1 < overflowCount
+		imageStore(voxelRadiance, position, vec4(mix(existingRadiance.rgb, overflowRadiance, weight), isNotLast * existingRadiance.w + 1));
+		imageStore(voxelNormals, position, vec4(mix(existingNormal.rgb, overflowNormal, weight), 1));
+	}
+}

--- a/src/graphics/graphics/vulkan/Renderer.cc
+++ b/src/graphics/graphics/vulkan/Renderer.cc
@@ -674,6 +674,7 @@ namespace sp::vulkan {
                 }
                 if (!vkMesh->CheckReady()) complete = false;
             }
+            if (!lighting.PreloadGelTextures(lock)) complete = false;
             return complete;
         });
 

--- a/src/graphics/graphics/vulkan/render_passes/Lighting.hh
+++ b/src/graphics/graphics/vulkan/render_passes/Lighting.hh
@@ -28,6 +28,8 @@ namespace sp::vulkan::renderer {
         void AddGelTextures(RenderGraph &graph);
         void AddLightingPass(RenderGraph &graph);
 
+        bool PreloadGelTextures(ecs::Lock<ecs::Read<ecs::Light>> lock);
+
     private:
         void AllocateShadowMap();
         GPUScene &scene;
@@ -55,7 +57,7 @@ namespace sp::vulkan::renderer {
             std::optional<uint32_t> opticIndex;
 
             std::string gelName;
-            const TextureIndex *gelTexture = nullptr;
+            std::optional<TextureIndex> gelTexture;
 
             bool operator==(const VirtualLight &) const;
         };


### PR DESCRIPTION
Adds a new single-worker loop to merge the last fragment list bucket in serial. This should fix the menu screenshot compare being flaky.

Texture preloading was also adding for light gel textures, so the flashlight will always work on the first frame of tests.