### PR TITLE
Editor fixes and world updates

### DIFF
--- a/assets/default_input_bindings.json
+++ b/assets/default_input_bindings.json
@@ -128,10 +128,16 @@
                 "outputs": "player:player/action/jump",
                 "filter": "is_focused(Game) && event"
             },
-            "/keyboard/key/e": {
-                "outputs": "player:pointer/interact/grab",
-                "filter": "is_focused(Game) && event"
-            },
+            "/keyboard/key/e": [
+                {
+                    "outputs": "player:pointer/interact/press",
+                    "filter": "is_focused(Game)"
+                },
+                {
+                    "outputs": "player:pointer/interact/grab",
+                    "filter": "is_focused(Game) && event"
+                }
+            ],
             "/keyboard/key/q": {
                 "outputs": "console:input/action/run_command",
                 "filter": "is_focused(Game) && event",

--- a/assets/scenes/life2.json
+++ b/assets/scenes/life2.json
@@ -109,6 +109,29 @@
 			}
 		},
 		{
+			"name": "spawn_button",
+			"transform": {
+				"parent": "table.surface",
+				"rotate": [90, 0, 0, -1],
+				"translate": [0.06, -0.11, -0.06]
+			},
+			"event_bindings": {
+				"/button/press": [
+					"life.3_3/life/toggle_alive",
+					"life.4_4/life/toggle_alive",
+					"life.4_5/life/toggle_alive",
+					"life.3_5/life/toggle_alive",
+					"life.2_5/life/toggle_alive"
+				]
+			},
+			"script": {
+				"parameters": {
+					"source": "button"
+				},
+				"prefab": "template"
+			}
+		},
+		{
 			"name": "mirrorcube1",
 			"transform": {
 				"scale": 0.1,

--- a/assets/scenes/sponza.json
+++ b/assets/scenes/sponza.json
@@ -215,7 +215,7 @@
 				"scale": 0.2
 			},
 			"voxel_area": {
-				"extents": [64, 64, 144]
+				"extents": [64, 80, 144]
 			}
 		},
 		{
@@ -225,7 +225,7 @@
 				"illuminance": 10,
 				"spot_angle": 22,
 				"shadow_map_size": 12,
-				"shadow_map_clip": [20, 50]
+				"shadow_map_clip": [25.5, 50]
 			},
 			"transform": {
 				"translate": [7, 35, 0],
@@ -235,6 +235,27 @@
 			"signal_output": {
 				"position": 0.2,
 				"fix_position": 1
+			}
+		},
+		{
+			"name": "skybox",
+			"transform": {
+				"scale": [30, 0.1, 90],
+				"translate": [0, 14.9, 0]
+			},
+			"renderable": {
+				"color_override": [0.3922, 0.7843, 1, 1],
+				"emissive": 1
+			},
+			"signal_output": {
+				"interact_holds": 0,
+				"interact_points": 50
+			},
+			"script": {
+				"parameters": {
+					"source": "blocks/box"
+				},
+				"prefab": "template"
 			}
 		}
 	]

--- a/assets/scenes/sponza.json
+++ b/assets/scenes/sponza.json
@@ -225,10 +225,10 @@
 				"illuminance": 10,
 				"spot_angle": 22,
 				"shadow_map_size": 12,
-				"shadow_map_clip": [25.5, 50]
+				"shadow_map_clip": [20, 50]
 			},
 			"transform": {
-				"translate": [7.947, 39.203, 0],
+				"translate": [7, 35, 0],
 				"rotate": [-90, 1, 0, 0]
 			},
 			"script": {"onTick": "sun"},
@@ -244,8 +244,9 @@
 				"translate": [0, 14.9, 0]
 			},
 			"renderable": {
-				"color_override": [0.3922, 0.7843, 1, 1],
-				"emissive": 1
+				"color_override": [0.529, 0.808, 0.922, 1],
+				"emissive": 1,
+				"visibility": "DirectCamera|DirectEye|LightingVoxel"
 			},
 			"signal_output": {
 				"interact_holds": 0,

--- a/assets/scenes/sponza.json
+++ b/assets/scenes/sponza.json
@@ -228,7 +228,7 @@
 				"shadow_map_clip": [25.5, 50]
 			},
 			"transform": {
-				"translate": [7, 35, 0],
+				"translate": [7.947, 39.203, 0],
 				"rotate": [-90, 1, 0, 0]
 			},
 			"script": {"onTick": "sun"},

--- a/assets/scenes/templates/blocks/box.json
+++ b/assets/scenes/templates/blocks/box.json
@@ -1,0 +1,14 @@
+{
+	"components": {
+		"transform": {},
+		"physics": {
+			"shapes": {
+				"box": [1, 1, 1]
+			},
+			"type": "Static"
+		},
+		"renderable": {
+			"model": "box"
+		}
+	}
+}

--- a/assets/scenes/templates/button.json
+++ b/assets/scenes/templates/button.json
@@ -146,12 +146,31 @@
 			}],
 			"signal_output": {},
 			"trigger_group": "Object",
-			"script": {
-				"onTick": "component_from_signal",
-				"parameters": {
-					"renderable.emissive": "scoperoot/light"
+			"event_input": {},
+			"event_bindings": {
+				"/interact/press": "button_actuator/signal/set/input_pressed"
+			},
+			"script": [
+				{
+					"onTick": "component_from_signal",
+					"parameters": {
+						"renderable.emissive": "scoperoot/light",
+						"physics.constant_force.x": "-0.2 + (!!button_actuator/input_pressed) * 0.4"
+					}
+				},
+				{
+					"onTick": "signal_from_event",
+					"parameters": {
+						"outputs": "input_pressed"
+					}
+				},
+				{
+					"onTick": "interactive_object",
+					"parameters": {
+						"highlight_only": true
+					}
 				}
-			}
+			]
 		}
 	]
 }

--- a/assets/scenes/tray.json
+++ b/assets/scenes/tray.json
@@ -206,6 +206,33 @@
 					}
 				}
 			]
+		},
+		{
+			"name": "box",
+			"transform": {
+				"parent": "root",
+				"translate": [0.5, 0.05, 0.3],
+				"scale": 0.1
+			},
+			"physics": {
+				"type": "Static",
+				"group": "UserInterface"
+			},
+			"event_input": {},
+			"script": [
+				{
+					"parameters": {
+						"source": "blocks/box"
+					},
+					"prefab": "template"
+				},
+				{
+					"onTick": "tray_spawner",
+					"parameters": {
+						"source": "blocks/box"
+					}
+				}
+			]
 		}
 	]
 }

--- a/assets/scenes/tray.json
+++ b/assets/scenes/tray.json
@@ -44,6 +44,12 @@
 			},
 			"script": [
 				{
+					"onTick": "interactive_object",
+					"parameters": {
+						"highlight_only": true
+					}
+				},
+				{
 					"parameters": {
 						"source": "blocks/laser_emitter"
 					},
@@ -68,6 +74,12 @@
 				"group": "UserInterface"
 			},
 			"script": [
+				{
+					"onTick": "interactive_object",
+					"parameters": {
+						"highlight_only": true
+					}
+				},
 				{
 					"parameters": {
 						"source": "blocks/laser_sensor"
@@ -94,6 +106,12 @@
 			},
 			"script": [
 				{
+					"onTick": "interactive_object",
+					"parameters": {
+						"highlight_only": true
+					}
+				},
+				{
 					"parameters": {
 						"source": "blocks/laser_gate"
 					},
@@ -118,6 +136,12 @@
 				"group": "UserInterface"
 			},
 			"script": [
+				{
+					"onTick": "interactive_object",
+					"parameters": {
+						"highlight_only": true
+					}
+				},
 				{
 					"parameters": {
 						"source": "blocks/mirror"
@@ -144,6 +168,12 @@
 			},
 			"script": [
 				{
+					"onTick": "interactive_object",
+					"parameters": {
+						"highlight_only": true
+					}
+				},
+				{
 					"parameters": {
 						"source": "blocks/splitter"
 					},
@@ -169,6 +199,12 @@
 			},
 			"script": [
 				{
+					"onTick": "interactive_object",
+					"parameters": {
+						"highlight_only": true
+					}
+				},
+				{
 					"parameters": {
 						"source": "blocks/charge_cell"
 					},
@@ -193,6 +229,12 @@
 				"group": "UserInterface"
 			},
 			"script": [
+				{
+					"onTick": "interactive_object",
+					"parameters": {
+						"highlight_only": true
+					}
+				},
 				{
 					"parameters": {
 						"source": "blocks/big_frame"
@@ -220,6 +262,12 @@
 			},
 			"event_input": {},
 			"script": [
+				{
+					"onTick": "interactive_object",
+					"parameters": {
+						"highlight_only": true
+					}
+				},
 				{
 					"parameters": {
 						"source": "blocks/box"

--- a/docs/generated/Runtime_Scripts.md
+++ b/docs/generated/Runtime_Scripts.md
@@ -189,6 +189,7 @@ The `init_event` script has parameter type: vector&lt;string&gt;
 | Parameter Name | Type | Default Value | Description |
 |------------|------|---------------|-------------|
 | **disabled** | bool | false | No description |
+| **highlight_only** | bool | false | No description |
 
 </div>
 

--- a/src/common/common/LockFreeEventQueue.hh
+++ b/src/common/common/LockFreeEventQueue.hh
@@ -42,7 +42,11 @@ namespace sp {
 
         void PushEvent(Event &&event) {
             std::lock_guard lock(eventMutex);
-            eventBuffer.emplace_back(std::move(event));
+            if (eventBuffer.size() < eventBuffer.capacity()) {
+                eventBuffer.emplace_back(std::move(event));
+            } else {
+                Errorf("LockFreeEventQueue full! Dropping event %s", typeid(Event).name());
+            }
         }
 
     private:

--- a/src/core/ecs/SignalRef.cc
+++ b/src/core/ecs/SignalRef.cc
@@ -63,9 +63,11 @@ namespace ecs {
         if (index < signals.signals.size()) {
             auto &signal = signals.signals[index];
             signal.value = value;
+            signals.MarkDirty(lock, index);
             return signal.value;
         } else {
             index = signals.NewSignal(lock, *this, value);
+            signals.MarkDirty(lock, index);
             return signals.signals[index].value;
         }
     }
@@ -79,6 +81,7 @@ namespace ecs {
 
         auto &signal = signals.signals[index];
         signal.value = -std::numeric_limits<double>::infinity();
+        signals.MarkDirty(lock, index);
         if (signal.expr.IsNull()) signals.FreeSignal(lock, index);
     }
 
@@ -113,9 +116,11 @@ namespace ecs {
         if (index < signals.signals.size()) {
             auto &signal = signals.signals[index];
             signal.expr = expr;
+            signals.MarkDirty(lock, index);
             return signal.expr;
         } else {
             index = signals.NewSignal(lock, *this, expr);
+            signals.MarkDirty(lock, index);
             return signals.signals[index].expr;
         }
     }
@@ -135,6 +140,7 @@ namespace ecs {
 
         auto &signal = signals.signals[index];
         signal.expr = SignalExpression();
+        signals.MarkDirty(lock, index);
         if (std::isinf(signal.value)) signals.FreeSignal(lock, index);
     }
 

--- a/src/core/ecs/components/Signals.cc
+++ b/src/core/ecs/components/Signals.cc
@@ -146,17 +146,16 @@ namespace ecs {
             // Noop
             DebugAssertf(signals.size() == other.signals.size() && dirtyIndices == other.dirtyIndices,
                 "Changes are different");
-        } else {
-            Assertf(other.changeCount == changeCount + 1,
-                "Signals storage copy skipped a change: %llu -> %llu",
-                changeCount,
-                other.changeCount);
-
+        } else if (other.changeCount == changeCount + 1) {
             if (signals.size() != other.signals.size()) signals.resize(other.signals.size());
             dirtyIndices = other.dirtyIndices;
             for (size_t index : other.dirtyIndices) {
                 signals[index] = other.signals[index];
             }
+            freeIndexes = other.freeIndexes;
+        } else {
+            dirtyIndices = other.dirtyIndices;
+            signals = other.signals;
             freeIndexes = other.freeIndexes;
         }
         changeCount = other.changeCount;

--- a/src/core/ecs/components/Signals.hh
+++ b/src/core/ecs/components/Signals.hh
@@ -38,7 +38,9 @@ namespace ecs {
             }
         };
 
+        uint32_t changeCount = 0;
         std::vector<Signal> signals;
+        std::set<size_t> dirtyIndices;
         std::priority_queue<size_t, std::vector<size_t>, std::greater<size_t>> freeIndexes;
 
         size_t NewSignal(const Lock<Write<Signals>> &lock, const SignalRef &ref, double value);
@@ -46,6 +48,10 @@ namespace ecs {
         void FreeSignal(const Lock<Write<Signals>> &lock, size_t index);
         void FreeEntitySignals(const Lock<Write<Signals>> &lock, Entity entity);
         void FreeMissingEntitySignals(const Lock<Write<Signals>> &lock);
+
+        void MarkDirty(const Lock<Write<Signals>> lock, size_t index);
+
+        Signals &operator=(const Signals &other);
     };
 
     struct SignalKey {

--- a/src/core/ecs/components/Signals.hh
+++ b/src/core/ecs/components/Signals.hh
@@ -39,13 +39,13 @@ namespace ecs {
         };
 
         std::vector<Signal> signals;
-        std::multimap<Entity, size_t> entityMapping;
         std::priority_queue<size_t, std::vector<size_t>, std::greater<size_t>> freeIndexes;
 
-        size_t NewSignal(const Lock<> &lock, const SignalRef &ref, double value);
-        size_t NewSignal(const Lock<> &lock, const SignalRef &ref, const SignalExpression &expr);
-        void FreeSignal(const Lock<> &lock, size_t index);
-        void FreeEntitySignals(const Lock<> &lock, Entity entity);
+        size_t NewSignal(const Lock<Write<Signals>> &lock, const SignalRef &ref, double value);
+        size_t NewSignal(const Lock<Write<Signals>> &lock, const SignalRef &ref, const SignalExpression &expr);
+        void FreeSignal(const Lock<Write<Signals>> &lock, size_t index);
+        void FreeEntitySignals(const Lock<Write<Signals>> &lock, Entity entity);
+        void FreeMissingEntitySignals(const Lock<Write<Signals>> &lock);
     };
 
     struct SignalKey {

--- a/src/game/game/Scene.cc
+++ b/src/game/game/Scene.cc
@@ -319,8 +319,6 @@ namespace sp {
                 Assert(sceneInfo.liveId.Has<ecs::SceneInfo>(live), "Expected liveId to have SceneInfo");
                 if (!remainingId.Has<ecs::SceneInfo>(staging)) {
                     // No more staging entities, remove the live id.
-                    auto &signals = live.Get<ecs::Signals>();
-                    signals.FreeEntitySignals(live, sceneInfo.liveId);
                     sceneInfo.liveId.Destroy(live);
                 } else {
                     auto &remainingInfo = remainingId.Get<ecs::SceneInfo>(staging);
@@ -333,11 +331,7 @@ namespace sp {
                 }
             }
             ecs::EntityRef ref = e;
-            if (!remainingId) {
-                // No more staging entities, clean up staging signals
-                auto &signals = staging.Get<ecs::Signals>();
-                signals.FreeEntitySignals(staging, e);
-            } else if (ref.GetStaging() == e) {
+            if (remainingId && ref.GetStaging() == e) {
                 // Update the entity ref to point to the new staging entity root.
                 ecs::GetEntityRefs().Set(ref.Name(), remainingId);
             }
@@ -356,6 +350,9 @@ namespace sp {
         auto stagingSceneId = data->sceneEntity.Get(staging);
         if (liveSceneId.Exists(live)) liveSceneId.Destroy(live);
         if (stagingSceneId.Exists(staging)) stagingSceneId.Destroy(staging);
+
+        live.Get<ecs::Signals>().FreeMissingEntitySignals(live);
+
         active = false;
     }
 

--- a/src/graphics/graphics/vulkan/Renderer.cc
+++ b/src/graphics/graphics/vulkan/Renderer.cc
@@ -675,6 +675,7 @@ namespace sp::vulkan {
                 if (!vkMesh->CheckReady()) complete = false;
             }
             if (!lighting.PreloadGelTextures(lock)) complete = false;
+            if (!smaa.PreloadTextures()) complete = false;
             return complete;
         });
 

--- a/src/graphics/graphics/vulkan/core/DeviceContext.cc
+++ b/src/graphics/graphics/vulkan/core/DeviceContext.cc
@@ -45,7 +45,7 @@ namespace sp::vulkan {
         if (messageType & deviceContext->disabledDebugMessages) return VK_FALSE;
 
         auto typeStr = vk::to_string(static_cast<vk::DebugUtilsMessageTypeFlagsEXT>(messageType));
-        string_view message(pCallbackData->pMessage);
+        string message(pCallbackData->pMessage);
 
         switch (messageSeverity) {
         case VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT:

--- a/src/graphics/graphics/vulkan/render_passes/SMAA.cc
+++ b/src/graphics/graphics/vulkan/render_passes/SMAA.cc
@@ -111,4 +111,10 @@ namespace sp::vulkan::renderer {
                 cmd.Draw(3);
             });
     }
+
+    bool SMAA::PreloadTextures() {
+        if (!areaTexAsset) areaTexAsset = Assets().LoadImage("textures/smaa/AreaTex.tga");
+        if (!searchTexAsset) searchTexAsset = Assets().LoadImage("textures/smaa/SearchTex.tga");
+        return areaTexAsset->Ready() && searchTexAsset->Ready();
+    }
 } // namespace sp::vulkan::renderer

--- a/src/graphics/graphics/vulkan/render_passes/SMAA.hh
+++ b/src/graphics/graphics/vulkan/render_passes/SMAA.hh
@@ -15,6 +15,8 @@ namespace sp::vulkan::renderer {
     public:
         void AddPass(RenderGraph &graph);
 
+        bool PreloadTextures();
+
     private:
         AsyncPtr<ImageView> areaTex, searchTex;
         AsyncPtr<sp::Image> areaTexAsset, searchTexAsset;


### PR DESCRIPTION
In this PR:
- Add basic skybox to sponza
- Make in-world buttons pressable with E or Left Click
- Add glider spawner button to life2 scene
- Add static box to editor
- Fix editor tray spawner script crashing
- Fix edit_tool scaling crashing physx when too small
- Fix crash if LockFreeEventQueue overflows due to lag
- Add hover outline to editor items
- Improve performance of ECS Signals commit copy by only copying changed signals
- Remove entityMapping from `ecs::Signals` and simplify code
- Add texture preload for SMAA lookup textures