### PR TITLE
Switch from `renderable.color_override` to `renderable.tint`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -207,7 +207,7 @@
             "type": "cppvsdbg",
             "request": "launch",
             "program": "${workspaceFolder}/bin/sp-test.exe",
-            "args": ["--with-validation-layers", "-v", "--assets", "../assets/", "--run", "tests/scene-overrides.txt"],
+            "args": ["--with-validation-layers", "-v", "--assets", "../assets/", "--run", "tests/life3.txt"],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}/bin",
             "environment": [],

--- a/assets/scenes/hello_world.json
+++ b/assets/scenes/hello_world.json
@@ -61,7 +61,7 @@
             },
             "renderable": {
                 "model": "box",
-                "color_override": [1, 0, 0, 1]
+                "tint": [1, 0, 0, 1]
             },
             "physics": {
                 "shapes": {
@@ -78,7 +78,7 @@
             },
             "renderable": {
                 "model": "box",
-                "color_override": [0, 0, 1, 1]
+                "tint": [0, 0, 1, 1]
             },
             "physics": {
                 "shapes": {

--- a/assets/scenes/mirrortest.json
+++ b/assets/scenes/mirrortest.json
@@ -157,7 +157,7 @@
 			"renderable": {
 				"model": "colorfilter",
 				"visibility": "Transparent|LightingShadow",
-				"color_override": [1, 0, 0, 0.5]
+				"tint": [1, 0, 0, 0.5]
 			},
 			"name": "redfilter",
 			"transform": {
@@ -182,7 +182,7 @@
 			"renderable": {
 				"model": "colorfilter",
 				"visibility": "Transparent|LightingShadow",
-				"color_override": [0, 1, 0, 0.5]
+				"tint": [0, 1, 0, 0.5]
 			},
 			"name": "greenfilter",
 			"transform": {
@@ -207,7 +207,7 @@
 			"renderable": {
 				"model": "colorfilter",
 				"visibility": "Transparent|LightingShadow",
-				"color_override": [0, 0, 1, 0.5]
+				"tint": [0, 0, 1, 0.5]
 			},
 			"name": "bluefilter",
 			"transform": {
@@ -232,7 +232,7 @@
 			"renderable": {
 				"model": "colorfilter",
 				"visibility": "Transparent|LightingShadow",
-				"color_override": [0, 1, 1, 0.5]
+				"tint": [0, 1, 1, 0.5]
 			},
 			"name": "cyanfilter",
 			"transform": {
@@ -257,7 +257,7 @@
 			"renderable": {
 				"model": "colorfilter",
 				"visibility": "Transparent|LightingShadow",
-				"color_override": [1, 0, 1, 0.5]
+				"tint": [1, 0, 1, 0.5]
 			},
 			"name": "magentafilter",
 			"transform": {
@@ -282,7 +282,7 @@
 			"renderable": {
 				"model": "colorfilter",
 				"visibility": "Transparent|LightingShadow",
-				"color_override": [1, 1, 0, 0.5]
+				"tint": [1, 1, 0, 0.5]
 			},
 			"name": "yellowfilter",
 			"transform": {

--- a/assets/scenes/sponza.json
+++ b/assets/scenes/sponza.json
@@ -244,7 +244,7 @@
 				"translate": [0, 14.9, 0]
 			},
 			"renderable": {
-				"color_override": [0.529, 0.808, 0.922, 1],
+				"tint": [0.529, 0.808, 0.922, 1],
 				"emissive": 1,
 				"visibility": "DirectCamera|DirectEye|LightingVoxel"
 			},

--- a/assets/scenes/templates/blocks/big_frame.json
+++ b/assets/scenes/templates/blocks/big_frame.json
@@ -117,7 +117,7 @@
 			},
 			"renderable": {
 				"model": "colorfilter",
-				"color_override": [0, 0, 0, 1],
+				"tint": [0, 0, 0, 1],
 				"metallic_roughness_override": [0.0, 1.0]
 			},
 			"physics": {

--- a/assets/scenes/templates/blocks/charge_cell.json
+++ b/assets/scenes/templates/blocks/charge_cell.json
@@ -72,7 +72,7 @@
 				"scale": 0.049
 			},
 			"renderable": {
-				"color_override": [0.03, 0.03, 0.04, 1],
+				"tint": [0.03, 0.03, 0.04, 1],
 				"metallic_roughness_override": [1, 0.6],
 				"model": "box"
 			}

--- a/assets/scenes/templates/blocks/laser_gate.json
+++ b/assets/scenes/templates/blocks/laser_gate.json
@@ -186,7 +186,7 @@
 			},
 			"renderable": {
 				"model": "occluder",
-				"color_override": [1, 1, 1, 1],
+				"tint": [1, 1, 1, 1],
                 "metallic_roughness_override": [1, 0],
 				"visibility": "Transparent|LightingShadow"
 			},
@@ -205,7 +205,7 @@
 				{
 					"onTick": "component_from_signal",
 					"parameters": {
-						"renderable.color_override.a": "!gate/value"
+						"renderable.tint.a": "!gate/value"
 					}
 				},
 				{
@@ -225,7 +225,7 @@
 			},
 			"renderable": {
 				"model": "occluder",
-				"color_override": [1, 1, 1, 0],
+				"tint": [1, 1, 1, 0],
                 "metallic_roughness_override": [1, 0],
 				"visibility": "Transparent|LightingShadow"
 			},
@@ -245,7 +245,7 @@
 				{
 					"onTick": "component_from_signal",
 					"parameters": {
-						"renderable.color_override.a": "gate/value"
+						"renderable.tint.a": "gate/value"
 					}
 				},
 				{

--- a/assets/scenes/templates/blocks/mirror.json
+++ b/assets/scenes/templates/blocks/mirror.json
@@ -60,7 +60,7 @@
 			},
 			"renderable": {
 				"model": "colorfilter",
-				"color_override": [0.95, 0.95, 0.95, 1.0],
+				"tint": [0.95, 0.95, 0.95, 1.0],
 				"metallic_roughness_override": [0.0, 0.0]
 			},
 			"physics": {

--- a/assets/scenes/templates/blocks/splitter.json
+++ b/assets/scenes/templates/blocks/splitter.json
@@ -62,7 +62,7 @@
 			"renderable": {
 				"model": "colorfilter",
 				"visibility": "Transparent|LightingShadow",
-				"color_override": [0.5, 0.5, 0.5, 0.5]
+				"tint": [0.5, 0.5, 0.5, 0.5]
 			},
 			"physics": {
 				"shapes": {

--- a/assets/scenes/templates/disable_block.json
+++ b/assets/scenes/templates/disable_block.json
@@ -19,7 +19,7 @@
 		{
 			"name": "mount.Cylinder",
 			"renderable": {
-				"color_override": [0, 0, 0, 1]
+				"tint": [0, 0, 0, 1]
 			}
 		}
 	]

--- a/assets/scenes/templates/fuel_pellet.json
+++ b/assets/scenes/templates/fuel_pellet.json
@@ -3,7 +3,7 @@
 		"renderable": {
 			"model": "sphere",
 			"emissive": 0.5,
-			"color_override": [0.1, 1.0, 0.2, 1]
+			"tint": [0.1, 1.0, 0.2, 1]
 		},
 		"physics": {
 			"shapes": {

--- a/assets/scenes/templates/fusion_core/fusion_laser.json
+++ b/assets/scenes/templates/fusion_core/fusion_laser.json
@@ -42,7 +42,7 @@
 			},
 			"renderable": {
 				"model": "dodecahedron",
-				"color_override": [0, 0, 0.05, 1]
+				"tint": [0, 0, 0.05, 1]
 			},
 			"physics": {
 				"shapes": {

--- a/assets/scenes/templates/table/life/life_cell.json
+++ b/assets/scenes/templates/table/life/life_cell.json
@@ -90,14 +90,14 @@
 			},
 			"_renderable": {
 				"model": "box",
-				"color_override": [0, 0, 0, 1]
+				"tint": [0, 0, 0, 1]
 			},
 			"_script": {
 				"onTick": "component_from_signal",
 				"parameters": {
-					"renderable.color_override.r": "scoperoot/neighbor_count < 2 || scoperoot/neighbor_count > 3",
-					"renderable.color_override.g": "scoperoot/alive",
-					"renderable.color_override.b": "scoperoot/next_alive"
+					"renderable.tint.r": "scoperoot/neighbor_count < 2 || scoperoot/neighbor_count > 3",
+					"renderable.tint.g": "scoperoot/alive",
+					"renderable.tint.b": "scoperoot/next_alive"
 				}
 			}
 		}

--- a/assets/scenes/templates/table/life/life_cell3.json
+++ b/assets/scenes/templates/table/life/life_cell3.json
@@ -3,14 +3,12 @@
 		"transform": {},
 		"signal_output": {
 			"alive": 0,
-			"age_alive": 0,
-			"age_dead": 100000
+			"age": 100000
 		},
 		"signal_bindings": {
 			"neighbor_count": "scoperoot/neighbor[-1][-1] + scoperoot/neighbor[-1][0] + scoperoot/neighbor[-1][1] + scoperoot/neighbor[0][-1] + scoperoot/neighbor[0][1] + scoperoot/neighbor[1][-1] + scoperoot/neighbor[1][0] + scoperoot/neighbor[1][1]",
 			"next_alive": "scoperoot/force_alive || (scoperoot/toggle_alive ? !scoperoot/alive : scoperoot/neighbor_count == 3 || (scoperoot/neighbor_count == 2 && scoperoot/alive))",
-			"decay_alive": "1 / (scoperoot/age_alive + 1)",
-			"decay_dead": "1 / (scoperoot/age_dead * scoperoot/age_dead + 1)"
+			"decay": "min(1, 1 / (scoperoot/age * scoperoot/age + 1))"
 		},
 		"event_input": {},
 		"event_bindings": {
@@ -43,8 +41,7 @@
 				"onTick": "signal_from_signal",
 				"parameters": {
 					"alive": "scoperoot/next_alive",
-					"age_alive": "scoperoot/alive ? scoperoot/age_alive + 1 : 0",
-					"age_dead": "!scoperoot/alive ? scoperoot/age_dead + 1 : 0"
+					"age": "scoperoot/alive >= scoperoot/next_alive ? scoperoot/age + 1 : 0"
 				}
 			},
 			{
@@ -72,9 +69,9 @@
 				{
 					"onTick": "component_from_signal",
 					"parameters": {
-						"renderable.emissive": "max(0.0001, max(scoperoot/decay_alive, scoperoot/decay_dead))",
-						"renderable.tint.rg": "min(scoperoot/alive, max(0.0001, scoperoot/decay_alive))",
-						"renderable.tint.b": "max(0.0001, scoperoot/decay_dead)"
+						"renderable.emissive": "max(0.001, scoperoot/decay) + scoperoot/alive",
+						"renderable.tint.rg": "max(0.0001, scoperoot/decay) * scoperoot/alive + scoperoot/alive",
+						"renderable.tint.b": "1 - max(0.0001, scoperoot/decay)"
 					}
 				}
 			]
@@ -88,8 +85,7 @@
 			},
 			"_renderable": {
 				"model": "box",
-				"tint": [0, 0, 0, 1],
-				"emissive": 0.1
+				"tint": [0, 0, 0, 1]
 			},
 			"_script": {
 				"onTick": "component_from_signal",

--- a/assets/scenes/templates/table/life/life_cell3.json
+++ b/assets/scenes/templates/table/life/life_cell3.json
@@ -3,12 +3,14 @@
 		"transform": {},
 		"signal_output": {
 			"alive": 0,
-			"age": 100000
+			"age_alive": 0,
+			"age_dead": 100000
 		},
 		"signal_bindings": {
 			"neighbor_count": "scoperoot/neighbor[-1][-1] + scoperoot/neighbor[-1][0] + scoperoot/neighbor[-1][1] + scoperoot/neighbor[0][-1] + scoperoot/neighbor[0][1] + scoperoot/neighbor[1][-1] + scoperoot/neighbor[1][0] + scoperoot/neighbor[1][1]",
 			"next_alive": "scoperoot/force_alive || (scoperoot/toggle_alive ? !scoperoot/alive : scoperoot/neighbor_count == 3 || (scoperoot/neighbor_count == 2 && scoperoot/alive))",
-			"decay": "min(1, 1 / (scoperoot/age * scoperoot/age + 1))"
+			"decay_alive": "1 / (scoperoot/age_alive + 1)",
+			"decay_dead": "1 / (scoperoot/age_dead * scoperoot/age_dead + 1)"
 		},
 		"event_input": {},
 		"event_bindings": {
@@ -41,7 +43,8 @@
 				"onTick": "signal_from_signal",
 				"parameters": {
 					"alive": "scoperoot/next_alive",
-					"age": "scoperoot/alive >= scoperoot/next_alive ? scoperoot/age + 1 : 0"
+					"age_alive": "scoperoot/alive ? scoperoot/age_alive + 1 : 0",
+					"age_dead": "!scoperoot/alive ? scoperoot/age_dead + 1 : 0"
 				}
 			},
 			{
@@ -62,16 +65,16 @@
 			},
 			"renderable": {
 				"model": "box",
-				"color_override": [1, 1, 1, 1]
+				"tint": [1, 1, 1, 1]
 			},
 			"event_input": {},
 			"script": [
 				{
 					"onTick": "component_from_signal",
 					"parameters": {
-						"renderable.emissive": "max(0.001, scoperoot/decay) + scoperoot/alive",
-						"renderable.color_override.rg": "max(0.0001, scoperoot/decay) * scoperoot/alive + scoperoot/alive",
-						"renderable.color_override.b": "1 - max(0.0001, scoperoot/decay)"
+						"renderable.emissive": "max(0.0001, max(scoperoot/decay_alive, scoperoot/decay_dead))",
+						"renderable.tint.rg": "min(scoperoot/alive, max(0.0001, scoperoot/decay_alive))",
+						"renderable.tint.b": "max(0.0001, scoperoot/decay_dead)"
 					}
 				}
 			]
@@ -85,14 +88,15 @@
 			},
 			"_renderable": {
 				"model": "box",
-				"color_override": [0, 0, 0, 1]
+				"tint": [0, 0, 0, 1],
+				"emissive": 0.1
 			},
 			"_script": {
 				"onTick": "component_from_signal",
 				"parameters": {
-					"renderable.color_override.r": "scoperoot/neighbor_count < 2 || scoperoot/neighbor_count > 3",
-					"renderable.color_override.g": "scoperoot/alive",
-					"renderable.color_override.b": "scoperoot/next_alive"
+					"renderable.tint.r": "scoperoot/neighbor_count < 2 || scoperoot/neighbor_count > 3",
+					"renderable.tint.g": "scoperoot/alive",
+					"renderable.tint.b": "scoperoot/next_alive"
 				}
 			}
 		}

--- a/assets/scenes/templates/table/life/wrap_corner.json
+++ b/assets/scenes/templates/table/life/wrap_corner.json
@@ -3,7 +3,7 @@
 		{
 			"name": "light",
 			"renderable": {
-				"color_override": [0.1, 0.1, 0.1, 1.0]
+				"tint": [0.1, 0.1, 0.1, 1.0]
 			}
 		}
 	]

--- a/assets/scenes/templates/table/life/wrap_edge.json
+++ b/assets/scenes/templates/table/life/wrap_edge.json
@@ -3,7 +3,7 @@
 		{
 			"name": "light",
 			"renderable": {
-				"color_override": [0.1, 0.1, 0.1, 1.0]
+				"tint": [0.1, 0.1, 0.1, 1.0]
 			}
 		}
 	]

--- a/docs/generated/Rendering_Components.md
+++ b/docs/generated/Rendering_Components.md
@@ -15,7 +15,7 @@ It is usually preferred to load the model using the [gltf Prefab Script](Prefab_
 | **mesh_index** | size_t | 0 | The index of the mesh to render from the GLTF model. Note, multi-mesh GLTF models can be automatically expanded into entities using the `gltf` prefab. |
 | **visibility** | enum flags [VisibilityMask](#VisibilityMask-type) | "DirectCamera\|DirectEye\|LightingShadow\|LightingVoxel" | Visibility mask for different render passes. |
 | **emissive** | float | 0 | Emissive multiplier to turn this model into a light source |
-| **color_override** | vec4 (red, green, blue, alpha) | [-1, -1, -1, -1] | Override the mesh's texture to a flat RGBA color. Values are in the range 0.0 to 1.0. -1 means the original color is used. |
+| **tint** | vec4 (red, green, blue, alpha) | [-1, -1, -1, -1] | Tint the mesh's texture with an RGBA color. Values are in the range 0.0 to 1.0. |
 | **metallic_roughness_override** | vec2 | [-1, -1] | Override the mesh's metallic and roughness material properties. Values are in the range 0.0 to 1.0. -1 means the original material is used. |
 
 <div class="type_definition">

--- a/docs/generated/scene.schema.json
+++ b/docs/generated/scene.schema.json
@@ -735,19 +735,7 @@
 					"physics_query": {},
 					"renderable": {
 						"properties": {
-							"color_override": {
-								"default": [-1, -1, -1, -1],
-								"description": "Override the mesh's texture to a flat RGBA color. Values are in the range 0.0 to 1.0. -1 means the original color is used.",
-								"items": {
-									"maximum": 1,
-									"minimum": 0,
-									"type": "number"
-								},
-								"maxItems": 4,
-								"minItems": 4,
-								"type": "array"
-							},
-							"emissive": {
+							"tint"
 								"default": 0,
 								"description": "Emissive multiplier to turn this model into a light source",
 								"type": "number"
@@ -772,6 +760,18 @@
 								"default": "",
 								"description": "Name of the GLTF model to display. Models are loaded from the `assets/models/` folder.",
 								"type": "string"
+							},
+							"tint": {
+								"default": [-1, -1, -1, -1],
+								"description": "Tint the mesh's texture with an RGBA color. Values are in the range 0.0 to 1.0.",
+								"items": {
+									"maximum": 1,
+									"minimum": 0,
+									"type": "number"
+								},
+								"maxItems": 4,
+								"minItems": 4,
+								"type": "array"
 							},
 							"visibility": {
 								"default": "DirectCamera|DirectEye|LightingShadow|LightingVoxel",

--- a/docs/generated/scene.schema.json
+++ b/docs/generated/scene.schema.json
@@ -735,7 +735,7 @@
 					"physics_query": {},
 					"renderable": {
 						"properties": {
-							"tint"
+							"emissive": {
 								"default": 0,
 								"description": "Emissive multiplier to turn this model into a light source",
 								"type": "number"

--- a/docs/guides/Building_a_Basic_Scene.md
+++ b/docs/guides/Building_a_Basic_Scene.md
@@ -148,7 +148,7 @@ Entities can be attached in a couple ways:
        },
        "renderable": {
            "model": "box",
-           "color_override": [1, 0, 0, 1]
+           "tint": [1, 0, 0, 1]
        },
        "physics": {
            "type": "SubActor",
@@ -160,7 +160,7 @@ Entities can be attached in a couple ways:
    ```
 
    This scales down the earlier `box` model, and places it on top of the cardboard box using relative positioning.
-   The new box is colored red using the `color_override` property of `renderable` so we can tell it apart.
+   The new box is colored red using the `tint` property of `renderable` so we can tell it apart.
 
    The `SubActor` physics type adds any physics shapes defined on this entity to the parent physics actor based on the `transform` parent.
    In this case the parent physics actor is the `hello_world:interactive-box` entity.
@@ -183,7 +183,7 @@ Entities can be attached in a couple ways:
        },
        "renderable": {
            "model": "box",
-           "color_override": [0, 0, 1, 1]
+           "tint": [0, 0, 1, 1]
        },
        "physics": {,
            "type": "Dynamic",

--- a/shaders/vulkan/generate_draws_for_view.comp
+++ b/shaders/vulkan/generate_draws_for_view.comp
@@ -63,13 +63,12 @@ void main() {
         draw.firstInstance = drawIndex;
         drawCommands[drawIndex] = draw;
 
-        drawParams[drawIndex].baseColorTexID = renderable.baseColorOverrideID >= 0
-                                                   ? uint16_t(renderable.baseColorOverrideID)
-                                                   : uint16_t(prim.baseColorTexID);
+        drawParams[drawIndex].baseColorTexID = uint16_t(prim.baseColorTexID);
         drawParams[drawIndex].metallicRoughnessTexID = renderable.metallicRoughnessOverrideID >= 0
                                                            ? uint16_t(renderable.metallicRoughnessOverrideID)
                                                            : uint16_t(prim.metallicRoughnessTexID);
         drawParams[drawIndex].opticID = uint16_t(renderable.opticID);
         drawParams[drawIndex].emissiveScale = float16_t(renderable.emissiveScale);
+        drawParams[drawIndex].baseColorTint = uint(renderable.baseColorTint);
     }
 }

--- a/shaders/vulkan/generate_gbuffer.frag
+++ b/shaders/vulkan/generate_gbuffer.frag
@@ -23,6 +23,7 @@ layout(location = 2) in vec2 inTexCoord;
 layout(location = 3) flat in int baseColorTexID;
 layout(location = 4) flat in int metallicRoughnessTexID;
 layout(location = 5) flat in float emissiveScale;
+layout(location = 6) flat in vec4 baseColorTint;
 
 layout(location = 0) out vec4 gBuffer0; // rgba8srgb
 layout(location = 1) out vec4 gBuffer1; // rgba16f
@@ -35,7 +36,7 @@ void main() {
     float roughness = metallicRoughnessSample.g;
     float metallic = metallicRoughnessSample.b;
 
-    gBuffer0.rgb = baseColor.rgb;
+    gBuffer0.rgb = mix(baseColor.rgb, baseColorTint.rgb, baseColorTint.a);
     gBuffer0.a = metallic;
     gBuffer1.rg = EncodeNormal(inNormal);
     gBuffer1.b = emissiveScale;

--- a/shaders/vulkan/lib/draw_params.glsl
+++ b/shaders/vulkan/lib/draw_params.glsl
@@ -10,4 +10,5 @@ struct DrawParams {
     uint16_t metallicRoughnessTexID;
     uint16_t opticID;
     float16_t emissiveScale;
+    uint baseColorTint; // RGBA packed u8
 };

--- a/shaders/vulkan/lib/scene.glsl
+++ b/shaders/vulkan/lib/scene.glsl
@@ -27,7 +27,7 @@ struct RenderableEntity {
     uint jointPosesOffset;
     uint opticID;
     float emissiveScale;
-    int baseColorOverrideID;
+    uint baseColorTint; // RGBA packed u8
     int metallicRoughnessOverrideID;
 };
 

--- a/shaders/vulkan/lighting_transparent.frag
+++ b/shaders/vulkan/lighting_transparent.frag
@@ -50,6 +50,7 @@ layout(location = 2) in vec2 inTexCoord;
 layout(location = 3) flat in int baseColorTexID;
 layout(location = 4) flat in int metallicRoughnessTexID;
 layout(location = 5) flat in float emissiveScale;
+layout(location = 6) flat in vec4 baseColorTint;
 layout(location = 0, index = 0) out vec4 outFragColor;
 layout(location = 0, index = 1) out vec4 outTransparencyMask;
 
@@ -60,7 +61,7 @@ void main() {
     ViewState view = views[gl_ViewID_OVR];
 
     vec4 baseColorAlpha = texture(textures[baseColorTexID], inTexCoord);
-    vec3 baseColor = baseColorAlpha.rgb * baseColorAlpha.a;
+    vec3 baseColor = mix(baseColorAlpha.rgb * baseColorAlpha.a, baseColorTint.rgb, baseColorTint.a);
     float scatterTerm = baseColorAlpha.a * scatterTermMultiplier;
 
     vec4 metallicRoughnessSample = texture(textures[metallicRoughnessTexID], inTexCoord);

--- a/shaders/vulkan/scene.vert
+++ b/shaders/vulkan/scene.vert
@@ -26,6 +26,7 @@ layout(location = 2) out vec2 outTexCoord;
 layout(location = 3) flat out int baseColorTexID;
 layout(location = 4) flat out int metallicRoughnessTexID;
 layout(location = 5) flat out float emissiveScale;
+layout(location = 6) flat out vec4 baseColorTint;
 
 #include "lib/draw_params.glsl"
 layout(std430, set = 1, binding = 0) readonly buffer DrawParamsList {
@@ -48,4 +49,8 @@ void main() {
     baseColorTexID = int(drawParams[gl_BaseInstance].baseColorTexID);
     metallicRoughnessTexID = int(drawParams[gl_BaseInstance].metallicRoughnessTexID);
     emissiveScale = float(drawParams[gl_BaseInstance].emissiveScale);
+    baseColorTint = vec4(float((drawParams[gl_BaseInstance].baseColorTint & 0xff000000) >> 24) / 255.0,
+        float((drawParams[gl_BaseInstance].baseColorTint & 0xff0000) >> 16) / 255.0,
+        float((drawParams[gl_BaseInstance].baseColorTint & 0xff00) >> 8) / 255.0,
+        float(drawParams[gl_BaseInstance].baseColorTint & 0xff) / 255.0);
 }

--- a/shaders/vulkan/voxel_fill.vert
+++ b/shaders/vulkan/voxel_fill.vert
@@ -24,6 +24,7 @@ layout(location = 3) out vec2 outTexCoord;
 layout(location = 4) flat out int baseColorTexID;
 layout(location = 5) flat out int metallicRoughnessTexID;
 layout(location = 6) flat out float emissiveScale;
+layout(location = 7) flat out vec4 baseColorTint;
 
 #include "lib/draw_params.glsl"
 layout(std430, set = 1, binding = 0) readonly buffer DrawParamsList {
@@ -51,6 +52,10 @@ void main() {
     baseColorTexID = int(drawParams[gl_BaseInstance].baseColorTexID);
     metallicRoughnessTexID = int(drawParams[gl_BaseInstance].metallicRoughnessTexID);
     emissiveScale = float(drawParams[gl_BaseInstance].emissiveScale);
+    baseColorTint.r = float((drawParams[gl_BaseInstance].baseColorTint & 0xff000000) >> 24) / 255.0;
+    baseColorTint.g = float((drawParams[gl_BaseInstance].baseColorTint & 0xff0000) >> 16) / 255.0;
+    baseColorTint.b = float((drawParams[gl_BaseInstance].baseColorTint & 0xff00) >> 8) / 255.0;
+    baseColorTint.a = float(drawParams[gl_BaseInstance].baseColorTint & 0xff) / 255.0;
 
     gl_ViewportIndex = int(gl_InstanceIndex - gl_BaseInstance);
 }

--- a/src/common/common/PreservingSet.hh
+++ b/src/common/common/PreservingSet.hh
@@ -160,6 +160,21 @@ namespace sp {
             }
         }
 
+        std::shared_ptr<T> Find(const T &value) {
+            std::shared_lock lock(mutex);
+
+            auto it = handles.find(value);
+            if (it != handles.end()) {
+                std::shared_ptr<T> ptr = *it;
+                size_t i = indexLookup.at(ptr.get());
+                Assertf(i < storage.size(), "PreservingSet index out of bounds");
+                storage[i].last_use = 0;
+                return ptr;
+            } else {
+                return nullptr;
+            }
+        }
+
         // Removes all values that have no references.
         // Values will have their destructors called inline by the current thread.
         // Returns the number of values that were removed.

--- a/src/core/ecs/SignalManager.cc
+++ b/src/core/ecs/SignalManager.cc
@@ -91,15 +91,7 @@ namespace ecs {
     }
 
     SignalNodePtr SignalManager::FindSignalNode(SignalRef ref) {
-        SignalNodePtr result;
-        signalNodes.ForEach([&](const Node &node, SignalNodePtr ptr) {
-            if (auto *signalNode = std::get_if<SignalNode>(&node)) {
-                if (signalNode->signal == ref) {
-                    result = ptr;
-                }
-            }
-        });
-        return result;
+        return signalNodes.Find(Node{SignalNode{ref}, ""});
     }
 
     std::vector<SignalNodePtr> SignalManager::GetNodes(const std::string &search) {

--- a/src/core/ecs/components/Renderable.hh
+++ b/src/core/ecs/components/Renderable.hh
@@ -59,7 +59,7 @@ namespace ecs {
         VisibilityMask visibility = VisibilityMask::DirectCamera | VisibilityMask::DirectEye |
                                     VisibilityMask::LightingShadow | VisibilityMask::LightingVoxel;
         float emissiveScale = 0;
-        sp::color_alpha_t colorOverride = glm::vec4(-1);
+        sp::color_alpha_t baseColorTint = glm::vec4(-1);
         glm::vec2 metallicRoughnessOverride = glm::vec2(-1);
 
         bool IsVisible(VisibilityMask viewMask) const {
@@ -87,10 +87,9 @@ It is usually preferred to load the model using the [gltf Prefab Script](Prefab_
         StructField::New("emissive",
             "Emissive multiplier to turn this model into a light source",
             &Renderable::emissiveScale),
-        StructField::New("color_override",
-            "Override the mesh's texture to a flat RGBA color. "
-            "Values are in the range 0.0 to 1.0. -1 means the original color is used.",
-            &Renderable::colorOverride),
+        StructField::New("tint",
+            "Tint the mesh's texture with an RGBA color. Values are in the range 0.0 to 1.0.",
+            &Renderable::baseColorTint),
         StructField::New("metallic_roughness_override",
             "Override the mesh's metallic and roughness material properties. "
             "Values are in the range 0.0 to 1.0. -1 means the original material is used.",

--- a/src/graphics/graphics/vulkan/scene/GPUScene.cc
+++ b/src/graphics/graphics/vulkan/scene/GPUScene.cc
@@ -79,9 +79,10 @@ namespace sp::vulkan {
             gpuRenderable.meshIndex = vkMesh->SceneIndex();
             gpuRenderable.vertexOffset = vertexCount;
             gpuRenderable.emissiveScale = renderable.emissiveScale;
-            if (glm::all(glm::greaterThanEqual(renderable.colorOverride.color, glm::vec4(0)))) {
-                gpuRenderable.baseColorOverrideID = textures.GetSinglePixelIndex(renderable.colorOverride);
-            }
+            gpuRenderable.baseColorTint = (uint32_t)(glm::clamp(renderable.baseColorTint[0], 0.0f, 1.0f) * 255) << 24 |
+                                          (uint32_t)(glm::clamp(renderable.baseColorTint[1], 0.0f, 1.0f) * 255) << 16 |
+                                          (uint32_t)(glm::clamp(renderable.baseColorTint[2], 0.0f, 1.0f) * 255) << 8 |
+                                          (uint32_t)(glm::clamp(renderable.baseColorTint[3], 0.0f, 1.0f) * 255);
             if (glm::all(glm::greaterThanEqual(renderable.metallicRoughnessOverride, glm::vec2(0)))) {
                 gpuRenderable.metallicRoughnessOverrideID = textures.GetSinglePixelIndex(
                     glm::vec4(renderable.metallicRoughnessOverride, 0, 1));
@@ -266,13 +267,13 @@ namespace sp::vulkan {
                         drawCmd.firstInstance = drawParams.size();
                         auto &drawParam = drawParams.emplace_back();
 
-                        drawParam.baseColorTexID = renderable.baseColorOverrideID >= 0 ? renderable.baseColorOverrideID
-                                                                                       : primitive.baseColor.index;
+                        drawParam.baseColorTexID = primitive.baseColor.index;
                         drawParam.metallicRoughnessTexID = renderable.metallicRoughnessOverrideID >= 0
                                                                ? renderable.metallicRoughnessOverrideID
                                                                : primitive.metallicRoughness.index;
                         drawParam.opticID = renderable.opticID;
                         drawParam.emissiveScale = renderable.emissiveScale;
+                        drawParam.baseColorTint = renderable.baseColorTint;
 
                         auto worldPos = renderable.modelToWorld * glm::vec4(primitive.center, 1);
                         auto relPos = (glm::vec3(worldPos) / worldPos.w) - viewPosition;

--- a/src/graphics/graphics/vulkan/scene/GPUScene.hh
+++ b/src/graphics/graphics/vulkan/scene/GPUScene.hh
@@ -66,7 +66,7 @@ namespace sp::vulkan {
         uint32_t jointPosesOffset = 0xffffffff;
         uint32_t opticID = 0;
         float emissiveScale = 0;
-        int32_t baseColorOverrideID = -1;
+        uint32_t baseColorTint = 0; // RGBA packed u8
         int32_t metallicRoughnessOverrideID = -1;
     };
     static_assert(sizeof(GPURenderableEntity) % sizeof(glm::vec4) == 0, "std430 alignment");
@@ -76,6 +76,7 @@ namespace sp::vulkan {
         uint16_t metallicRoughnessTexID;
         uint16_t opticID = 0;
         float16_t emissiveScale = 0.0f;
+        uint32_t baseColorTint = 0; // RGBA packed u8
     };
     static_assert(sizeof(GPUDrawParams) % sizeof(uint16_t) == 0, "std430 alignment");
 


### PR DESCRIPTION
This changes the behavior slightly to allow for partial-tinting of the existing base color texture instead of only replacing the color entirely.