### PR TITLE
Fix slowness of FindSignalNode

### DIFF
--- a/src/common/common/PreservingSet.hh
+++ b/src/common/common/PreservingSet.hh
@@ -160,6 +160,21 @@ namespace sp {
             }
         }
 
+        std::shared_ptr<T> Find(const T &value) {
+            std::shared_lock lock(mutex);
+
+            auto it = handles.find(value);
+            if (it != handles.end()) {
+                std::shared_ptr<T> ptr = *it;
+                size_t i = indexLookup.at(ptr.get());
+                Assertf(i < storage.size(), "PreservingSet index out of bounds");
+                storage[i].last_use = 0;
+                return ptr;
+            } else {
+                return nullptr;
+            }
+        }
+
         // Removes all values that have no references.
         // Values will have their destructors called inline by the current thread.
         // Returns the number of values that were removed.

--- a/src/core/ecs/SignalManager.cc
+++ b/src/core/ecs/SignalManager.cc
@@ -91,15 +91,7 @@ namespace ecs {
     }
 
     SignalNodePtr SignalManager::FindSignalNode(SignalRef ref) {
-        SignalNodePtr result;
-        signalNodes.ForEach([&](const Node &node, SignalNodePtr ptr) {
-            if (auto *signalNode = std::get_if<SignalNode>(&node)) {
-                if (signalNode->signal == ref) {
-                    result = ptr;
-                }
-            }
-        });
-        return result;
+        return signalNodes.Find(Node{SignalNode{ref}, ""});
     }
 
     std::vector<SignalNodePtr> SignalManager::GetNodes(const std::string &search) {


### PR DESCRIPTION
Switches from iterating to using a hash lookup, which massively improves the loading time of `life3` in debug.