### PR TITLE
Combined anisotropic voxel processing into fewer passes

### DIFF
--- a/assets/scenes/system/player.json
+++ b/assets/scenes/system/player.json
@@ -91,7 +91,7 @@
 		},
 		{
 			"name": "tray_attachment",
-			"scene_connection": { "tray": "0" },
+			"scene_connection": { "editor/tray": "0" },
 			"transform": {
 				"parent": "direction",
 				"translate": [0, 1, -1]

--- a/shaders/vulkan/voxel_fill_layer.comp
+++ b/shaders/vulkan/voxel_fill_layer.comp
@@ -37,8 +37,8 @@ void main() {
     vec3 radiance = vec3(fragmentLists[index].radiance);
     vec3 voxelNormal = mat3(voxelInfo.worldToVoxel) * vec3(fragmentLists[index].normal);
 
-	for (int i = 0; i < 6; i++) {
-		float alpha = max(0, dot(voxelNormal, -AxisDirections[i]));
-		imageStore(radianceOut[i], position, vec4(radiance, 1) * alpha);
-	}
+    for (int i = 0; i < 6; i++) {
+        float alpha = max(0, dot(voxelNormal, -AxisDirections[i]));
+        imageStore(radianceOut[i], position, vec4(radiance, 1) * alpha);
+    }
 }

--- a/shaders/vulkan/voxel_fill_layer.comp
+++ b/shaders/vulkan/voxel_fill_layer.comp
@@ -27,13 +27,7 @@ layout(std430, binding = 2) buffer VoxelFragmentList {
     VoxelFragment fragmentLists[];
 };
 
-layout(binding = 3, rgba16f) writeonly uniform image3D[6] radianceOut;
-// radianceOutPosX
-// radianceOutPosY
-// radianceOutPosZ
-// radianceOutNegX
-// radianceOutNegY
-// radianceOutNegZ
+layout(binding = 3, rgba16f) writeonly uniform image3D radianceOut[6];
 
 void main() {
     uint index = gl_WorkGroupID.x * (gl_WorkGroupSize.x * gl_WorkGroupSize.y) + gl_LocalInvocationIndex;

--- a/shaders/vulkan/voxel_fill_layer.comp
+++ b/shaders/vulkan/voxel_fill_layer.comp
@@ -16,33 +16,35 @@ layout(binding = 0) uniform VoxelStateUniform {
     VoxelState voxelInfo;
 };
 
-layout(binding = 1) uniform LayerDataUniform {
-    vec3 layerDirection;
-    uint layerIndex;
-};
-
-layout(binding = 2, rgba16f) writeonly uniform image3D radianceOut;
-
-layout(std430, binding = 3) buffer VoxelFragmentListMetadata {
+layout(std430, binding = 1) buffer VoxelFragmentListMetadata {
     uint count;
     uint capacity;
     uint offset;
     VkDispatchIndirectCommand cmd;
 };
 
-layout(std430, binding = 4) buffer VoxelFragmentList {
+layout(std430, binding = 2) buffer VoxelFragmentList {
     VoxelFragment fragmentLists[];
 };
+
+layout(binding = 3, rgba16f) writeonly uniform image3D[6] radianceOut;
+// radianceOutPosX
+// radianceOutPosY
+// radianceOutPosZ
+// radianceOutNegX
+// radianceOutNegY
+// radianceOutNegZ
 
 void main() {
     uint index = gl_WorkGroupID.x * (gl_WorkGroupSize.x * gl_WorkGroupSize.y) + gl_LocalInvocationIndex;
     if (index >= count) return;
-    if (layerIndex > 0) return;
 
     ivec3 position = ivec3(fragmentLists[index].position);
     vec3 radiance = vec3(fragmentLists[index].radiance);
     vec3 voxelNormal = mat3(voxelInfo.worldToVoxel) * vec3(fragmentLists[index].normal);
 
-    float alpha = max(0, dot(voxelNormal, -layerDirection));
-    imageStore(radianceOut, position, vec4(radiance, 1) * alpha);
+	for (int i = 0; i < 6; i++) {
+		float alpha = max(0, dot(voxelNormal, -AxisDirections[i]));
+		imageStore(radianceOut[i], position, vec4(radiance, 1) * alpha);
+	}
 }

--- a/shaders/vulkan/voxel_merge_layer.comp
+++ b/shaders/vulkan/voxel_merge_layer.comp
@@ -27,7 +27,7 @@ layout(std430, binding = 2) buffer VoxelFragmentList {
     VoxelFragment fragmentLists[]; // Already bound at +offset
 };
 
-layout(binding = 3, rgba16f) uniform image3D[6] voxelLayer;
+layout(binding = 3, rgba16f) uniform image3D voxelLayer[6];
 
 layout(constant_id = 0) const int FRAGMENT_LIST_INDEX = 1;
 

--- a/shaders/vulkan/voxel_merge_layer.comp
+++ b/shaders/vulkan/voxel_merge_layer.comp
@@ -16,23 +16,18 @@ layout(binding = 0) uniform VoxelStateUniform {
     VoxelState voxelInfo;
 };
 
-layout(binding = 1) uniform LayerDataUniform {
-    vec3 layerDirection;
-    uint layerIndex;
-};
-
-layout(binding = 2, rgba16f) uniform image3D voxelLayer;
-
-layout(std430, binding = 3) buffer VoxelFragmentListMetadata {
+layout(std430, binding = 1) buffer VoxelFragmentListMetadata {
     uint count;
     uint capacity;
     uint offset;
     VkDispatchIndirectCommand cmd;
 };
 
-layout(std430, binding = 4) buffer VoxelFragmentList {
+layout(std430, binding = 2) buffer VoxelFragmentList {
     VoxelFragment fragmentLists[]; // Already bound at +offset
 };
+
+layout(binding = 3, rgba16f) uniform image3D[6] voxelLayer;
 
 layout(constant_id = 0) const int FRAGMENT_LIST_INDEX = 1;
 
@@ -43,13 +38,15 @@ void main() {
     ivec3 position = ivec3(fragmentLists[index].position);
     vec3 overflowRadiance = vec3(fragmentLists[index].radiance);
     vec3 overflowNormal = mat3(voxelInfo.worldToVoxel) * vec3(fragmentLists[index].normal);
-    float alpha = max(0, dot(overflowNormal, -layerDirection));
-    overflowRadiance *= alpha;
 
-    vec4 radiance = imageLoad(voxelLayer, position);
-    radiance.a += alpha;
-    if (radiance.a > 0) {
-        radiance.rgb = mix(radiance.rgb, overflowRadiance, alpha / radiance.a);
-        imageStore(voxelLayer, position, radiance);
-    }
+	for (int i = 0; i < 6; i++) {
+		float alpha = max(0, dot(overflowNormal, -AxisDirections[i]));
+
+		vec4 radiance = imageLoad(voxelLayer[i], position);
+		radiance.a += alpha;
+		if (radiance.a > 0) {
+			radiance.rgb = mix(radiance.rgb, overflowRadiance * alpha, alpha / radiance.a);
+			imageStore(voxelLayer[i], position, radiance);
+		}
+	}
 }

--- a/shaders/vulkan/voxel_merge_layer.comp
+++ b/shaders/vulkan/voxel_merge_layer.comp
@@ -39,14 +39,14 @@ void main() {
     vec3 overflowRadiance = vec3(fragmentLists[index].radiance);
     vec3 overflowNormal = mat3(voxelInfo.worldToVoxel) * vec3(fragmentLists[index].normal);
 
-	for (int i = 0; i < 6; i++) {
-		float alpha = max(0, dot(overflowNormal, -AxisDirections[i]));
+    for (int i = 0; i < 6; i++) {
+        float alpha = max(0, dot(overflowNormal, -AxisDirections[i]));
 
-		vec4 radiance = imageLoad(voxelLayer[i], position);
-		radiance.a += alpha;
-		if (radiance.a > 0) {
-			radiance.rgb = mix(radiance.rgb, overflowRadiance * alpha, alpha / radiance.a);
-			imageStore(voxelLayer[i], position, radiance);
-		}
-	}
+        vec4 radiance = imageLoad(voxelLayer[i], position);
+        radiance.a += alpha;
+        if (radiance.a > 0) {
+            radiance.rgb = mix(radiance.rgb, overflowRadiance * alpha, alpha / radiance.a);
+            imageStore(voxelLayer[i], position, radiance);
+        }
+    }
 }

--- a/shaders/vulkan/voxel_merge_layer_serial.comp
+++ b/shaders/vulkan/voxel_merge_layer_serial.comp
@@ -7,7 +7,7 @@
 
 #version 460
 
-layout(local_size_x = 1, local_size_y = 1) in;
+layout(local_size_x = 6, local_size_y = 1) in;
 
 #include "../lib/types_common.glsl"
 #include "../lib/voxel_shared.glsl"
@@ -16,23 +16,18 @@ layout(binding = 0) uniform VoxelStateUniform {
     VoxelState voxelInfo;
 };
 
-layout(binding = 1) uniform LayerDataUniform {
-    vec3 layerDirection;
-    uint layerIndex;
-};
-
-layout(binding = 2, rgba16f) uniform image3D voxelLayer;
-
-layout(std430, binding = 3) buffer VoxelFragmentListMetadata {
+layout(std430, binding = 1) buffer VoxelFragmentListMetadata {
     uint count;
     uint capacity;
     uint offset;
     VkDispatchIndirectCommand cmd;
 };
 
-layout(std430, binding = 4) buffer VoxelFragmentList {
+layout(std430, binding = 2) buffer VoxelFragmentList {
     VoxelFragment fragmentLists[]; // Already bound at +offset
 };
+
+layout(binding = 3, rgba16f) uniform image3D[6] voxelLayer;
 
 layout(constant_id = 0) const int FRAGMENT_LIST_COUNT = 1;
 
@@ -41,14 +36,13 @@ void main() {
         ivec3 position = ivec3(fragmentLists[index].position);
         vec3 overflowRadiance = vec3(fragmentLists[index].radiance);
         vec3 overflowNormal = mat3(voxelInfo.worldToVoxel) * vec3(fragmentLists[index].normal);
-        float alpha = max(0, dot(overflowNormal, -layerDirection));
-        overflowRadiance *= alpha;
 
-        vec4 radiance = imageLoad(voxelLayer, position);
+        float alpha = max(0, dot(overflowNormal, -AxisDirections[gl_LocalInvocationIndex]));
+        vec4 radiance = imageLoad(voxelLayer[gl_LocalInvocationIndex], position);
         radiance.a += alpha;
         if (radiance.a > 0) {
-            radiance.rgb = mix(radiance.rgb, overflowRadiance, alpha / radiance.a);
-            imageStore(voxelLayer, position, radiance);
+            radiance.rgb = mix(radiance.rgb, overflowRadiance * alpha, alpha / radiance.a);
+            imageStore(voxelLayer[gl_LocalInvocationIndex], position, radiance);
         }
     }
 }

--- a/shaders/vulkan/voxel_merge_layer_serial.comp
+++ b/shaders/vulkan/voxel_merge_layer_serial.comp
@@ -27,7 +27,7 @@ layout(std430, binding = 2) buffer VoxelFragmentList {
     VoxelFragment fragmentLists[]; // Already bound at +offset
 };
 
-layout(binding = 3, rgba16f) uniform image3D[6] voxelLayer;
+layout(binding = 3, rgba16f) uniform image3D voxelLayer[6];
 
 layout(constant_id = 0) const int FRAGMENT_LIST_COUNT = 1;
 

--- a/shaders/vulkan/voxel_mipmap_layer.comp
+++ b/shaders/vulkan/voxel_mipmap_layer.comp
@@ -16,49 +16,46 @@ layout(local_size_x = 8, local_size_y = 8, local_size_z = 8) in;
 layout(binding = 0) uniform VoxelStateUniform {
     VoxelState voxelInfo;
 };
-
-layout(binding = 1) uniform LayerDataUniform {
-    vec3 layerDirection;
-    uint layerIndex;
-};
-
-layout(binding = 2) uniform sampler3D voxelLayerIn;
-layout(binding = 3, rgba16f) writeonly uniform image3D voxelLayerOut;
-
-layout(binding = 4) uniform PreviousVoxelStateUniform {
+layout(binding = 1) uniform PreviousVoxelStateUniform {
     VoxelState previousVoxelInfo;
 };
-layout(binding = 5) uniform sampler3D prevFrameVoxelLayer;
+
+layout(binding = 2) uniform sampler3D voxelLayerIn[6];
+layout(binding = 8, rgba16f) writeonly uniform image3D voxelLayerOut[6];
+layout(binding = 14) uniform sampler3D prevFrameVoxelLayer[6];
 
 layout(constant_id = 0) const float PREVIOUS_FRAME_BLEND = 0;
+layout(constant_id = 1) const uint layerIndex = 0;
 
 void main() {
     ivec3 voxelPos = ivec3(gl_GlobalInvocationID);
-    if (any(greaterThanEqual(voxelPos, imageSize(voxelLayerOut)))) return;
+    if (any(greaterThanEqual(voxelPos, imageSize(voxelLayerOut[0])))) return;
 
-    int stride = 1; // << max(0, int(layerIndex) - 1);
-    ivec3 layerOffset = ivec3(layerDirection) * stride;
+	for (int i = 0; i < 6; i++) {
+		int stride = 1; // << max(0, int(layerIndex) - 1);
+		ivec3 layerOffset = ivec3(AxisDirections[i]) * stride;
 
-    vec4 frontSample = texelFetch(voxelLayerIn, voxelPos, 0);
-    vec4 backSample = texelFetch(voxelLayerIn, voxelPos + layerOffset, 0);
-    if (layerIndex == 1) {
-        // Alpha acts as voxel fill count on first layer
-        frontSample /= max(1, frontSample.a);
-        backSample /= max(1, backSample.a);
+		vec4 frontSample = texelFetch(voxelLayerIn[i], voxelPos, 0);
+		vec4 backSample = texelFetch(voxelLayerIn[i], voxelPos + layerOffset, 0);
+		if (layerIndex == 1) {
+			// Alpha acts as voxel fill count on first layer
+			frontSample /= max(1, frontSample.a);
+			backSample /= max(1, backSample.a);
 
-        if (PREVIOUS_FRAME_BLEND > 0) {
-            vec4 worldPosition = inverse(voxelInfo.worldToVoxel) * vec4(voxelPos + 0.5f, 1.0);
-            ivec3 reprojectedVoxelPos = ivec3(previousVoxelInfo.worldToVoxel * worldPosition);
-            vec4 previousSample = texelFetch(prevFrameVoxelLayer, reprojectedVoxelPos, 0);
-            float weight = PREVIOUS_FRAME_BLEND * (1 - 0.2 * step(length(frontSample), length(previousSample)));
-            frontSample = mix(frontSample, previousSample, clamp(weight, 0, 1));
-        }
-    }
-    backSample.rgb *= pow(0.95, stride); // Voxel trace distance falloff
+			if (PREVIOUS_FRAME_BLEND > 0) {
+				vec4 worldPosition = inverse(voxelInfo.worldToVoxel) * vec4(voxelPos + 0.5f, 1.0);
+				ivec3 reprojectedVoxelPos = ivec3(previousVoxelInfo.worldToVoxel * worldPosition);
+				vec4 previousSample = texelFetch(prevFrameVoxelLayer[i], reprojectedVoxelPos, 0);
+				float weight = PREVIOUS_FRAME_BLEND * (1 - 0.2 * step(length(frontSample), length(previousSample)));
+				frontSample = mix(frontSample, previousSample, clamp(weight, 0, 1));
+			}
+		}
+		backSample.rgb *= pow(0.95, stride); // Voxel trace distance falloff
 
-    vec4 sampleValue = vec4(0);
-    sampleValue.a = frontSample.a + backSample.a * max(0, 1 - frontSample.a);
-    sampleValue.rgb = frontSample.rgb + backSample.rgb * max(0, 1 - frontSample.a);
+		vec4 sampleValue = vec4(0);
+		sampleValue.a = frontSample.a + backSample.a * max(0, 1 - frontSample.a);
+		sampleValue.rgb = frontSample.rgb + backSample.rgb * max(0, 1 - frontSample.a);
 
-    imageStore(voxelLayerOut, ivec3(voxelPos), sampleValue);
+		imageStore(voxelLayerOut[i], ivec3(voxelPos), sampleValue);
+	}
 }

--- a/shaders/vulkan/voxel_mipmap_layer.comp
+++ b/shaders/vulkan/voxel_mipmap_layer.comp
@@ -31,31 +31,31 @@ void main() {
     ivec3 voxelPos = ivec3(gl_GlobalInvocationID);
     if (any(greaterThanEqual(voxelPos, imageSize(voxelLayerOut[0])))) return;
 
-	for (int i = 0; i < 6; i++) {
-		int stride = 1; // << max(0, int(layerIndex) - 1);
-		ivec3 layerOffset = ivec3(AxisDirections[i]) * stride;
+    for (int i = 0; i < 6; i++) {
+        int stride = 1; // << max(0, int(layerIndex) - 1);
+        ivec3 layerOffset = ivec3(AxisDirections[i]) * stride;
 
-		vec4 frontSample = texelFetch(voxelLayerIn[i], voxelPos, 0);
-		vec4 backSample = texelFetch(voxelLayerIn[i], voxelPos + layerOffset, 0);
-		if (layerIndex == 1) {
-			// Alpha acts as voxel fill count on first layer
-			frontSample /= max(1, frontSample.a);
-			backSample /= max(1, backSample.a);
+        vec4 frontSample = texelFetch(voxelLayerIn[i], voxelPos, 0);
+        vec4 backSample = texelFetch(voxelLayerIn[i], voxelPos + layerOffset, 0);
+        if (layerIndex == 1) {
+            // Alpha acts as voxel fill count on first layer
+            frontSample /= max(1, frontSample.a);
+            backSample /= max(1, backSample.a);
 
-			if (PREVIOUS_FRAME_BLEND > 0) {
-				vec4 worldPosition = inverse(voxelInfo.worldToVoxel) * vec4(voxelPos + 0.5f, 1.0);
-				ivec3 reprojectedVoxelPos = ivec3(previousVoxelInfo.worldToVoxel * worldPosition);
-				vec4 previousSample = texelFetch(prevFrameVoxelLayer[i], reprojectedVoxelPos, 0);
-				float weight = PREVIOUS_FRAME_BLEND * (1 - 0.2 * step(length(frontSample), length(previousSample)));
-				frontSample = mix(frontSample, previousSample, clamp(weight, 0, 1));
-			}
-		}
-		backSample.rgb *= pow(0.95, stride); // Voxel trace distance falloff
+            if (PREVIOUS_FRAME_BLEND > 0) {
+                vec4 worldPosition = inverse(voxelInfo.worldToVoxel) * vec4(voxelPos + 0.5f, 1.0);
+                ivec3 reprojectedVoxelPos = ivec3(previousVoxelInfo.worldToVoxel * worldPosition);
+                vec4 previousSample = texelFetch(prevFrameVoxelLayer[i], reprojectedVoxelPos, 0);
+                float weight = PREVIOUS_FRAME_BLEND * (1 - 0.2 * step(length(frontSample), length(previousSample)));
+                frontSample = mix(frontSample, previousSample, clamp(weight, 0, 1));
+            }
+        }
+        backSample.rgb *= pow(0.95, stride); // Voxel trace distance falloff
 
-		vec4 sampleValue = vec4(0);
-		sampleValue.a = frontSample.a + backSample.a * max(0, 1 - frontSample.a);
-		sampleValue.rgb = frontSample.rgb + backSample.rgb * max(0, 1 - frontSample.a);
+        vec4 sampleValue = vec4(0);
+        sampleValue.a = frontSample.a + backSample.a * max(0, 1 - frontSample.a);
+        sampleValue.rgb = frontSample.rgb + backSample.rgb * max(0, 1 - frontSample.a);
 
-		imageStore(voxelLayerOut[i], ivec3(voxelPos), sampleValue);
-	}
+        imageStore(voxelLayerOut[i], ivec3(voxelPos), sampleValue);
+    }
 }

--- a/shaders/vulkan/voxel_mipmap_layer_blur.comp
+++ b/shaders/vulkan/voxel_mipmap_layer_blur.comp
@@ -26,54 +26,54 @@ void main() {
 
     int stride = 1; // << max(0, int(layerIndex) - 2); // max(1, int(layerIndex) - 1);
 
-	for (int axis = 0; axis < 6; axis++) {
-		ivec3 tangentAxisA = ivec3(AxisDirections[TangentAxisA[axis]]) * stride;
-		ivec3 tangentAxisB = ivec3(AxisDirections[TangentAxisB[axis]]) * stride;
+    for (int axis = 0; axis < 6; axis++) {
+        ivec3 tangentAxisA = ivec3(AxisDirections[TangentAxisA[axis]]) * stride;
+        ivec3 tangentAxisB = ivec3(AxisDirections[TangentAxisB[axis]]) * stride;
 
-		vec3 forwardOffset = vec3(0.5 + AxisDirections[axis] * 0.5);
-		vec3 gridSize = imageSize(voxelLayerOut[axis]);
-		vec4[4] tangentSamples = vec4[](
-			texture(prevFrameVoxelLayer[OppositeAxis[TangentAxisA[axis]]], (voxelPos + forwardOffset) / gridSize),
-			texture(prevFrameVoxelLayer[OppositeAxis[TangentAxisB[axis]]], (voxelPos + forwardOffset) / gridSize),
-			texture(prevFrameVoxelLayer[TangentAxisA[axis]], (voxelPos + forwardOffset) / gridSize),
-			texture(prevFrameVoxelLayer[TangentAxisB[axis]], (voxelPos + forwardOffset) / gridSize));
+        vec3 forwardOffset = vec3(0.5 + AxisDirections[axis] * 0.5);
+        vec3 gridSize = imageSize(voxelLayerOut[axis]);
+        vec4[4] tangentSamples = vec4[](
+            texture(prevFrameVoxelLayer[OppositeAxis[TangentAxisA[axis]]], (voxelPos + forwardOffset) / gridSize),
+            texture(prevFrameVoxelLayer[OppositeAxis[TangentAxisB[axis]]], (voxelPos + forwardOffset) / gridSize),
+            texture(prevFrameVoxelLayer[TangentAxisA[axis]], (voxelPos + forwardOffset) / gridSize),
+            texture(prevFrameVoxelLayer[TangentAxisB[axis]], (voxelPos + forwardOffset) / gridSize));
 
-		// Alpha acts as voxel fill count on first layer
-		tangentSamples[0] /= max(1, tangentSamples[0].a);
-		tangentSamples[1] /= max(1, tangentSamples[1].a);
-		tangentSamples[2] /= max(1, tangentSamples[2].a);
-		tangentSamples[3] /= max(1, tangentSamples[3].a);
+        // Alpha acts as voxel fill count on first layer
+        tangentSamples[0] /= max(1, tangentSamples[0].a);
+        tangentSamples[1] /= max(1, tangentSamples[1].a);
+        tangentSamples[2] /= max(1, tangentSamples[2].a);
+        tangentSamples[3] /= max(1, tangentSamples[3].a);
 
-		vec4[4] cornerSamples = vec4[]((tangentSamples[0] + tangentSamples[1]) * 0.5,
-			(tangentSamples[0] + tangentSamples[3]) * 0.5,
-			(tangentSamples[2] + tangentSamples[1]) * 0.5,
-			(tangentSamples[2] + tangentSamples[3]) * 0.5);
+        vec4[4] cornerSamples = vec4[]((tangentSamples[0] + tangentSamples[1]) * 0.5,
+            (tangentSamples[0] + tangentSamples[3]) * 0.5,
+            (tangentSamples[2] + tangentSamples[1]) * 0.5,
+            (tangentSamples[2] + tangentSamples[3]) * 0.5);
 
-		vec4[3][3] alphaSamples = vec4[][](vec4[](cornerSamples[0], tangentSamples[0], cornerSamples[1]),
-			vec4[](tangentSamples[1], vec4(0), tangentSamples[3]),
-			vec4[](cornerSamples[2], tangentSamples[2], cornerSamples[3]));
+        vec4[3][3] alphaSamples = vec4[][](vec4[](cornerSamples[0], tangentSamples[0], cornerSamples[1]),
+            vec4[](tangentSamples[1], vec4(0), tangentSamples[3]),
+            vec4[](cornerSamples[2], tangentSamples[2], cornerSamples[3]));
 
-		vec4 sampleValue = vec4(0);
-		float count = 0;
-		for (int i = -1; i <= 1; i++) {
-			for (int j = -1; j <= 1; j++) {
-				ivec3 samplePos = voxelPos + tangentAxisA * i + tangentAxisB * j;
+        vec4 sampleValue = vec4(0);
+        float count = 0;
+        for (int i = -1; i <= 1; i++) {
+            for (int j = -1; j <= 1; j++) {
+                ivec3 samplePos = voxelPos + tangentAxisA * i + tangentAxisB * j;
 
-				vec4 frontSample = alphaSamples[i + 1][j + 1] * vec4(vec3(0.707), 1);
-				vec4 backSample = texelFetch(voxelLayerIn[axis], samplePos, 0);
-				if (layerIndex == 1) {
-					backSample /= max(1, backSample.a);
-				}
+                vec4 frontSample = alphaSamples[i + 1][j + 1] * vec4(vec3(0.707), 1);
+                vec4 backSample = texelFetch(voxelLayerIn[axis], samplePos, 0);
+                if (layerIndex == 1) {
+                    backSample /= max(1, backSample.a);
+                }
 
-				vec4 combined = vec4(0);
-				combined.a = frontSample.a + backSample.a * max(0, 1 - frontSample.a);
-				combined.rgb = frontSample.rgb + backSample.rgb * max(0, 1 - frontSample.a);
+                vec4 combined = vec4(0);
+                combined.a = frontSample.a + backSample.a * max(0, 1 - frontSample.a);
+                combined.rgb = frontSample.rgb + backSample.rgb * max(0, 1 - frontSample.a);
 
-				float weight = pow(0.95, stride * length(vec2(i, j)));
-				count += weight;
-				sampleValue += combined * weight;
-			}
-		}
-		imageStore(voxelLayerOut[axis], ivec3(voxelPos), sampleValue / count);
-	}
+                float weight = pow(0.95, stride * length(vec2(i, j)));
+                count += weight;
+                sampleValue += combined * weight;
+            }
+        }
+        imageStore(voxelLayerOut[axis], ivec3(voxelPos), sampleValue / count);
+    }
 }

--- a/shaders/vulkan/voxel_mipmap_layer_blur.comp
+++ b/shaders/vulkan/voxel_mipmap_layer_blur.comp
@@ -13,77 +13,67 @@ layout(local_size_x = 8, local_size_y = 8, local_size_z = 8) in;
 #include "../lib/util.glsl"
 #include "../lib/voxel_shared.glsl"
 
-layout(binding = 0) uniform LayerDataUniform {
-    vec3 layerDirection;
-    uint layerIndex;
-};
+layout(binding = 0, rgba16f) writeonly uniform image3D voxelLayerOut[6];
 
-layout(binding = 1, rgba16f) writeonly uniform image3D voxelLayerOut;
+layout(binding = 6) uniform sampler3D voxelLayerIn[6];
+layout(binding = 12) uniform sampler3D prevFrameVoxelLayer[6];
 
-layout(binding = 2) uniform sampler3D voxelLayerIn;
-layout(binding = 3) uniform sampler3D baseVoxelLayers[6];
+layout(constant_id = 0) const uint layerIndex = 0;
 
 void main() {
     ivec3 voxelPos = ivec3(gl_GlobalInvocationID);
-    if (any(greaterThanEqual(voxelPos, imageSize(voxelLayerOut)))) return;
-
-    // imageStore(voxelLayerOut, ivec3(voxelPos), texelFetch(voxelLayerIn, voxelPos, 0));
-    // return;
+    if (any(greaterThanEqual(voxelPos, imageSize(voxelLayerOut[0])))) return;
 
     int stride = 1; // << max(0, int(layerIndex) - 2); // max(1, int(layerIndex) - 1);
 
-    int axis = DominantAxis(layerDirection);
-    if (axis < 0) {
-        axis = -axis + 2;
-    } else {
-        axis -= 1;
-    }
-    ivec3 tangentAxisA = ivec3(AxisDirections[TangentAxisA[axis]]) * stride;
-    ivec3 tangentAxisB = ivec3(AxisDirections[TangentAxisB[axis]]) * stride;
+	for (int axis = 0; axis < 6; axis++) {
+		ivec3 tangentAxisA = ivec3(AxisDirections[TangentAxisA[axis]]) * stride;
+		ivec3 tangentAxisB = ivec3(AxisDirections[TangentAxisB[axis]]) * stride;
 
-    vec3 forwardOffset = vec3(0.5 + AxisDirections[axis] * 0.5);
-    vec3 gridSize = imageSize(voxelLayerOut);
-    vec4[4] tangentSamples = vec4[](
-        texture(baseVoxelLayers[OppositeAxis[TangentAxisA[axis]]], (voxelPos + forwardOffset) / gridSize),
-        texture(baseVoxelLayers[OppositeAxis[TangentAxisB[axis]]], (voxelPos + forwardOffset) / gridSize),
-        texture(baseVoxelLayers[TangentAxisA[axis]], (voxelPos + forwardOffset) / gridSize),
-        texture(baseVoxelLayers[TangentAxisB[axis]], (voxelPos + forwardOffset) / gridSize));
+		vec3 forwardOffset = vec3(0.5 + AxisDirections[axis] * 0.5);
+		vec3 gridSize = imageSize(voxelLayerOut[axis]);
+		vec4[4] tangentSamples = vec4[](
+			texture(prevFrameVoxelLayer[OppositeAxis[TangentAxisA[axis]]], (voxelPos + forwardOffset) / gridSize),
+			texture(prevFrameVoxelLayer[OppositeAxis[TangentAxisB[axis]]], (voxelPos + forwardOffset) / gridSize),
+			texture(prevFrameVoxelLayer[TangentAxisA[axis]], (voxelPos + forwardOffset) / gridSize),
+			texture(prevFrameVoxelLayer[TangentAxisB[axis]], (voxelPos + forwardOffset) / gridSize));
 
-    // Alpha acts as voxel fill count on first layer
-    tangentSamples[0] /= max(1, tangentSamples[0].a);
-    tangentSamples[1] /= max(1, tangentSamples[1].a);
-    tangentSamples[2] /= max(1, tangentSamples[2].a);
-    tangentSamples[3] /= max(1, tangentSamples[3].a);
+		// Alpha acts as voxel fill count on first layer
+		tangentSamples[0] /= max(1, tangentSamples[0].a);
+		tangentSamples[1] /= max(1, tangentSamples[1].a);
+		tangentSamples[2] /= max(1, tangentSamples[2].a);
+		tangentSamples[3] /= max(1, tangentSamples[3].a);
 
-    vec4[4] cornerSamples = vec4[]((tangentSamples[0] + tangentSamples[1]) * 0.5,
-        (tangentSamples[0] + tangentSamples[3]) * 0.5,
-        (tangentSamples[2] + tangentSamples[1]) * 0.5,
-        (tangentSamples[2] + tangentSamples[3]) * 0.5);
+		vec4[4] cornerSamples = vec4[]((tangentSamples[0] + tangentSamples[1]) * 0.5,
+			(tangentSamples[0] + tangentSamples[3]) * 0.5,
+			(tangentSamples[2] + tangentSamples[1]) * 0.5,
+			(tangentSamples[2] + tangentSamples[3]) * 0.5);
 
-    vec4[3][3] alphaSamples = vec4[][](vec4[](cornerSamples[0], tangentSamples[0], cornerSamples[1]),
-        vec4[](tangentSamples[1], vec4(0), tangentSamples[3]),
-        vec4[](cornerSamples[2], tangentSamples[2], cornerSamples[3]));
+		vec4[3][3] alphaSamples = vec4[][](vec4[](cornerSamples[0], tangentSamples[0], cornerSamples[1]),
+			vec4[](tangentSamples[1], vec4(0), tangentSamples[3]),
+			vec4[](cornerSamples[2], tangentSamples[2], cornerSamples[3]));
 
-    vec4 sampleValue = vec4(0);
-    float count = 0;
-    for (int i = -1; i <= 1; i++) {
-        for (int j = -1; j <= 1; j++) {
-            ivec3 samplePos = voxelPos + tangentAxisA * i + tangentAxisB * j;
+		vec4 sampleValue = vec4(0);
+		float count = 0;
+		for (int i = -1; i <= 1; i++) {
+			for (int j = -1; j <= 1; j++) {
+				ivec3 samplePos = voxelPos + tangentAxisA * i + tangentAxisB * j;
 
-            vec4 frontSample = alphaSamples[i + 1][j + 1] * vec4(vec3(0.707), 1);
-            vec4 backSample = texelFetch(voxelLayerIn, samplePos, 0);
-            if (layerIndex == 1) {
-                backSample /= max(1, backSample.a);
-            }
+				vec4 frontSample = alphaSamples[i + 1][j + 1] * vec4(vec3(0.707), 1);
+				vec4 backSample = texelFetch(voxelLayerIn[axis], samplePos, 0);
+				if (layerIndex == 1) {
+					backSample /= max(1, backSample.a);
+				}
 
-            vec4 combined = vec4(0);
-            combined.a = frontSample.a + backSample.a * max(0, 1 - frontSample.a);
-            combined.rgb = frontSample.rgb + backSample.rgb * max(0, 1 - frontSample.a);
+				vec4 combined = vec4(0);
+				combined.a = frontSample.a + backSample.a * max(0, 1 - frontSample.a);
+				combined.rgb = frontSample.rgb + backSample.rgb * max(0, 1 - frontSample.a);
 
-            float weight = pow(0.95, stride * length(vec2(i, j)));
-            count += weight;
-            sampleValue += combined * weight;
-        }
-    }
-    imageStore(voxelLayerOut, ivec3(voxelPos), sampleValue / count);
+				float weight = pow(0.95, stride * length(vec2(i, j)));
+				count += weight;
+				sampleValue += combined * weight;
+			}
+		}
+		imageStore(voxelLayerOut[axis], ivec3(voxelPos), sampleValue / count);
+	}
 }

--- a/src/core/ecs/SignalExpression.cc
+++ b/src/core/ecs/SignalExpression.cc
@@ -1013,6 +1013,7 @@ namespace ecs {
 
     void SignalExpression::SetScope(const EntityScope &scope) {
         this->scope = scope;
+        if (!rootNode) return;
         SignalNodePtr newRoot = rootNode->SetScope(scope);
         if (newRoot) {
             newRoot->Compile();


### PR DESCRIPTION
Instead of dispatching 6 compute shaders, looping 6 times inside 1 computer shader eliminates quite a bit of overhead.

Also fixes the editor tray not opening