### PR TITLE
Improved collision force calculation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -53,7 +53,7 @@
             "type": "cppvsdbg",
             "request": "launch",
             "program": "${workspaceFolder}/bin/sp-vk.exe",
-            "args": ["--with-validation-layers", "--assets", "../assets/", "--no-vr"],
+            "args": ["--with-validation-layers", "--assets", "../assets/", "--no-vr", "--verbose"],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}/bin",
             "environment": [],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -53,7 +53,7 @@
             "type": "cppvsdbg",
             "request": "launch",
             "program": "${workspaceFolder}/bin/sp-vk.exe",
-            "args": ["--with-validation-layers", "--assets", "../assets/", "--no-vr", "--verbose"],
+            "args": ["--with-validation-layers", "--assets", "../assets/", "--no-vr"],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}/bin",
             "environment": [],

--- a/assets/scenes/editor/tray.json
+++ b/assets/scenes/editor/tray.json
@@ -281,6 +281,74 @@
 					}
 				}
 			]
+		},
+		{
+			"name": "cardboard_box",
+			"transform": {
+				"parent": "root",
+				"translate": [0.8, 0.05, 0.3],
+				"scale": 0.1
+			},
+			"physics": {
+				"type": "Static",
+				"group": "UserInterface"
+			},
+			"event_input": {},
+			"script": [
+				{
+					"onTick": "interactive_object",
+					"parameters": {
+						"highlight_only": true
+					}
+				},
+				{
+					"parameters": {
+						"source": "blocks/cardboard_box"
+					},
+					"prefab": "template"
+				},
+				{
+					"onTick": "tray_spawner",
+					"parameters": {
+						"source": "blocks/cardboard_box",
+						"reset_scale": true
+					}
+				}
+			]
+		},
+		{
+			"name": "1mirror_cube",
+			"transform": {
+				"parent": "root",
+				"translate": [0.8, 0.05, 0.2],
+				"scale": 0.1
+			},
+			"physics": {
+				"type": "Static",
+				"group": "UserInterface"
+			},
+			"event_input": {},
+			"script": [
+				{
+					"onTick": "interactive_object",
+					"parameters": {
+						"highlight_only": true
+					}
+				},
+				{
+					"parameters": {
+						"source": "blocks/1mirror_cube"
+					},
+					"prefab": "template"
+				},
+				{
+					"onTick": "tray_spawner",
+					"parameters": {
+						"source": "blocks/1mirror_cube",
+						"reset_scale": true
+					}
+				}
+			]
 		}
 	]
 }

--- a/assets/scenes/templates/blocks/1mirror_cube.json
+++ b/assets/scenes/templates/blocks/1mirror_cube.json
@@ -1,7 +1,6 @@
 {
 	"components": {
-		"transform": {
-		},
+		"transform": {},
 		"physics": {
 			"shapes": {
 				"model": "box",
@@ -11,6 +10,8 @@
 			},
 			"mass": 2
 		},
+		"physics_joints": [],
+		"event_input": {},
 		"script": [
 			{
 				"prefab": "gltf",
@@ -22,14 +23,8 @@
 			{
 				"prefab": "template",
 				"parameters": { "source": "interactive" }
-			},
-			{
-				"onTick": "magnetic_plug"
 			}
-		],
-		"physics_joints": [],
-		"trigger_group": "Magnetic",
-		"event_input": {}
+		]
 	},
 	"entities": [
 		{

--- a/assets/scenes/templates/blocks/cardboard_box.json
+++ b/assets/scenes/templates/blocks/cardboard_box.json
@@ -1,0 +1,20 @@
+{
+	"components": {
+		"transform": {},
+		"physics": {
+			"shapes": {
+				"model": "cardboard-box"
+			},
+			"mass": 1
+		},
+		"renderable": {
+			"model": "cardboard-box"
+		},
+		"physics_joints": [],
+		"event_input": {},
+		"script": {
+			"prefab": "template",
+			"parameters": { "source": "interactive" }
+		}
+	}
+}

--- a/assets/scenes/templates/duck.json
+++ b/assets/scenes/templates/duck.json
@@ -17,8 +17,9 @@
 					"modify": "event * 0.0015"
 				},
 				{
-					"outputs": "scoperoot/sound/play",
-					"set_value": 0
+					"outputs": ["scoperoot/sound/play", "scoperoot/signal/set/last_play"],
+					"set_value": 0,
+					"filter": "scoperoot/last_play > 40"
 				}
 			]
 		},
@@ -30,6 +31,18 @@
 			},
 			{
 				"onTick": "volume_control"
+			},
+			{
+				"onTick": "signal_from_signal",
+				"parameters": {
+					"last_play": "scoperoot/last_play + 1"
+				}
+			},
+			{
+				"onTick": "signal_from_event",
+				"parameters": {
+					"outputs": "last_play"
+				}
 			}
 		]
 	},

--- a/assets/scenes/templates/duck.json
+++ b/assets/scenes/templates/duck.json
@@ -4,22 +4,34 @@
 		"physics": {
 			"type": "Dynamic",
 			"mass": 1,
-			"contact_report_force": 100
+			"contact_report_force": 1
 		},
 		"audio": [{
 			"file": "quack.ogg",
 			"volume": 0.3
 		}],
 		"event_bindings": {
-			"/physics/collision/force_found": {
-				"outputs": "scoperoot/sound/play",
-				"set_value": 0
-			}
+			"/physics/collision/force_found": [
+				{
+					"outputs": "scoperoot/volume/set",
+					"modify": "event * 0.0015"
+				},
+				{
+					"outputs": "scoperoot/sound/play",
+					"set_value": 0
+				}
+			]
 		},
-		"script": {
-			"prefab": "template",
-			"parameters": { "source": "interactive" }
-		}
+		"event_input": {},
+		"script": [
+			{
+				"prefab": "template",
+				"parameters": { "source": "interactive" }
+			},
+			{
+				"onTick": "volume_control"
+			}
+		]
 	},
 	"entities": [
 		{

--- a/docs/generated/Runtime_Scripts.md
+++ b/docs/generated/Runtime_Scripts.md
@@ -539,6 +539,21 @@ The `sun` script has no configurable parameters
 | Parameter Name | Type | Default Value | Description |
 |------------|------|---------------|-------------|
 | **source** | string | "" | No description |
+| **reset_scale** | bool | false | No description |
+
+</div>
+
+
+<div class="component_definition">
+
+## `volume_control` Script
+
+| Parameter Name | Type | Default Value | Description |
+|------------|------|---------------|-------------|
+| **volume** | [SignalExpression](#SignalExpression-type) | "" | No description |
+
+**See Also:**
+[SignalExpression](#SignalExpression-type)
 
 </div>
 

--- a/docs_generator/markdown_gen.hh
+++ b/docs_generator/markdown_gen.hh
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "assets/JsonHelpers.hh"
+#include "common/Common.hh"
 #include "ecs/Ecs.hh"
 #include "ecs/StructFieldTypes.hh"
 
@@ -72,7 +73,7 @@ private:
         } else if constexpr (sp::json::detail::is_unordered_map<T>()) {
             return "map&lt;" + fieldTypeName<typename T::key_type>() + ", " + fieldTypeName<typename T::mapped_type>() +
                    "&gt;";
-        } else if constexpr (sp::json::detail::is_optional<T>()) {
+        } else if constexpr (sp::is_optional<T>()) {
             return "optional&lt;" + fieldTypeName<typename T::value_type>() + "&gt;";
         } else if constexpr (std::is_enum<T>()) {
             static const auto enumName = magic_enum::enum_type_name<T>();
@@ -99,7 +100,7 @@ public:
             auto &defaultValue = defaultPtr ? *reinterpret_cast<const T *>(defaultPtr) : defaultStruct;
 
             picojson::value defaultJson;
-            if constexpr (!sp::json::detail::is_optional<T>()) {
+            if constexpr (!sp::is_optional<T>()) {
                 defaultJson = picojson::value(picojson::object());
                 sp::json::Save(ecs::EntityScope(), defaultJson, defaultValue);
             }

--- a/src/common/common/Common.hh
+++ b/src/common/common/Common.hh
@@ -30,6 +30,7 @@ typedef std::chrono::steady_clock chrono_clock;
 #include <algorithm>
 #include <glm/glm.hpp>
 #include <glm/gtx/string_cast.hpp>
+#include <variant>
 
 typedef unsigned char uint8;
 typedef signed char int8;
@@ -199,6 +200,16 @@ namespace sp {
 
     template<typename T>
     struct is_vector<std::vector<T>> : std::true_type {};
+
+    template<typename T>
+    struct is_optional : std::false_type {};
+    template<typename T>
+    struct is_optional<std::optional<T>> : std::true_type {};
+
+    template<typename T>
+    struct is_variant : std::false_type {};
+    template<typename... Tn>
+    struct is_variant<std::variant<Tn...>> : std::true_type {};
 
     template<typename T>
     struct is_glm_vec : std::false_type {};

--- a/src/common/common/Common.hh
+++ b/src/common/common/Common.hh
@@ -30,6 +30,7 @@ typedef std::chrono::steady_clock chrono_clock;
 #include <algorithm>
 #include <glm/glm.hpp>
 #include <glm/gtx/string_cast.hpp>
+#include <optional>
 #include <variant>
 
 typedef unsigned char uint8;

--- a/src/core/assets/JsonHelpers.hh
+++ b/src/core/assets/JsonHelpers.hh
@@ -54,11 +54,6 @@ namespace sp::json {
         }
 
         template<typename T>
-        struct is_optional : std::false_type {};
-        template<typename T>
-        struct is_optional<std::optional<T>> : std::true_type {};
-
-        template<typename T>
         struct is_unordered_map : std::false_type {};
         template<typename K, typename V>
         struct is_unordered_map<robin_hood::unordered_flat_map<K, V>> : std::true_type {};
@@ -511,7 +506,7 @@ namespace sp::json {
             typeSchema["minItems"] = picojson::value((double)T::length());
             typeSchema["maxItems"] = picojson::value((double)T::length());
             SaveSchema<typename T::value_type>(typeSchema["items"], references, false);
-        } else if constexpr (detail::is_optional<T>()) {
+        } else if constexpr (is_optional<T>()) {
             typeSchema["default"] = picojson::value();
             SaveSchema<typename T::value_type>(dst, references, false);
         } else if constexpr (sp::is_vector<T>()) {

--- a/src/core/ecs/EventQueue.cc
+++ b/src/core/ecs/EventQueue.cc
@@ -73,7 +73,7 @@ namespace ecs {
             src);
     }
 
-    std::string Event::toString() const {
+    std::string Event::ToString() const {
         std::stringstream ss;
         ss << this->name << ":" << this->data;
         return ss.str();

--- a/src/core/ecs/EventQueue.hh
+++ b/src/core/ecs/EventQueue.hh
@@ -55,7 +55,7 @@ namespace ecs {
         template<typename T>
         Event(const std::string &name, const Entity &source, const T &data) : name(name), source(source), data(data) {}
 
-        std::string toString() const;
+        std::string ToString() const;
     };
 
     struct AsyncEvent {

--- a/src/core/ecs/SignalStructAccess_common.hh
+++ b/src/core/ecs/SignalStructAccess_common.hh
@@ -83,6 +83,12 @@ namespace ecs::detail {
                 }
             }
             return true;
+        } else if constexpr (sp::is_variant<T>::value) {
+            return std::visit(
+                [&](auto &&innerValue) {
+                    return ConvertAccessor<ArgT>(innerValue, accessor);
+                },
+                value);
         } else {
             return false;
         }

--- a/src/game/console/ConsoleBindingManager.cc
+++ b/src/game/console/ConsoleBindingManager.cc
@@ -33,7 +33,7 @@ namespace sp {
                             if (command && !command->empty()) {
                                 GetConsoleManager().QueueParseAndExecute(*command);
                             } else {
-                                Errorf("Console binding received invalid event: %s", event.toString());
+                                Errorf("Console binding received invalid event: %s", event.ToString());
                             }
                         }
                     });

--- a/src/graphics/graphics/gui/definitions/InspectorGui.cc
+++ b/src/graphics/graphics/gui/definitions/InspectorGui.cc
@@ -61,7 +61,7 @@ namespace sp {
                 if (event.name != EDITOR_EVENT_EDIT_TARGET) continue;
 
                 if (!std::holds_alternative<ecs::Entity>(event.data)) {
-                    Errorf("Invalid editor event: %s", event.toString());
+                    Errorf("Invalid editor event: %s", event.ToString());
                 } else {
                     auto newTarget = std::get<ecs::Entity>(event.data);
                     targetEntity = newTarget;

--- a/src/graphics/graphics/vulkan/render_passes/Voxels.hh
+++ b/src/graphics/graphics/vulkan/render_passes/Voxels.hh
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "Common.hh"
+#include "console/CFunc.hh"
 #include "graphics/vulkan/scene/GPUScene.hh"
 
 namespace sp::vulkan::renderer {
@@ -23,7 +24,7 @@ namespace sp::vulkan::renderer {
 
     class Voxels {
     public:
-        Voxels(GPUScene &scene) : scene(scene) {}
+        Voxels(GPUScene &scene);
         void LoadState(RenderGraph &graph, ecs::Lock<ecs::Read<ecs::VoxelArea, ecs::TransformSnapshot>> lock);
 
         void AddVoxelization(RenderGraph &graph, const Lighting &lighting);
@@ -52,6 +53,9 @@ namespace sp::vulkan::renderer {
 
         std::array<vk::DescriptorSet, 2> layerDescriptorSets;
         uint32_t currentSetFrame = 0;
+
+        std::atomic_flag debugThisFrame;
+        CFuncCollection funcs;
 
         void updateDescriptorSet(rg::Resources &resources, DeviceContext &device);
 

--- a/src/scripts/scripts/AudioScripts.cc
+++ b/src/scripts/scripts/AudioScripts.cc
@@ -8,6 +8,7 @@
 #include "common/Common.hh"
 #include "common/Logging.hh"
 #include "ecs/EcsImpl.hh"
+#include "ecs/SignalStructAccess_common.hh"
 #include "game/GameEntities.hh"
 #include "game/Scene.hh"
 
@@ -54,6 +55,44 @@ namespace sp::scripts {
     StructMetadata MetadataSoundOcclusion(typeid(SoundOcclusion), "SoundOcclusion", "");
     InternalScript<SoundOcclusion> soundOcclusion("sound_occlusion", MetadataSoundOcclusion);
 
+    struct VolumeControl {
+        SignalExpression volumeInput;
+
+        void Init(ScriptState &state) {
+            state.definition.events.clear();
+            if (volumeInput.expr.empty()) {
+                state.definition.events.emplace_back("/volume/set");
+                state.definition.filterOnEvent = true;
+            }
+        }
+
+        void OnTick(ScriptState &state, Lock<WriteAll> lock, Entity ent, chrono_clock::duration interval) {
+            if (!ent.Has<Audio>(lock)) return;
+            auto &sounds = ent.Get<Audio>(lock).sounds;
+            if (sounds.empty()) return;
+
+            Event event;
+            while (EventInput::Poll(lock, state.eventQueue, event)) {
+                if (event.name == "/volume/set") {
+                    bool success = ecs::detail::ConvertAccessor<const float>(event.data, [&](const float &value) {
+                        sounds[0].volume = glm::clamp(value, 0.0f, 1.0f);
+                    });
+                    if (!success) {
+                        Logf("Couldn't convert from %s to float", event.ToString());
+                    }
+                }
+            }
+            if (!volumeInput.expr.empty()) {
+                sounds[0].volume = glm::clamp(volumeInput.Evaluate(lock), 0.0, 1.0);
+            }
+        }
+    };
+    StructMetadata MetadataVolumeControl(typeid(VolumeControl),
+        "VolumeControl",
+        "",
+        StructField::New("volume", &VolumeControl::volumeInput));
+    InternalScript<VolumeControl> volumeControl("volume_control", MetadataVolumeControl);
+
     struct SpeedControlledSound {
         bool init = false;
         Transform lastTransform;
@@ -90,5 +129,5 @@ namespace sp::scripts {
         }
     };
     StructMetadata MetadataSpeedControlledSound(typeid(SpeedControlledSound), "SpeedControlledSound", "");
-    InternalScript<SpeedControlledSound> elevator("speed_controlled_sound", MetadataSpeedControlledSound);
+    InternalScript<SpeedControlledSound> speedControlledSound("speed_controlled_sound", MetadataSpeedControlledSound);
 } // namespace sp::scripts

--- a/src/scripts/scripts/EditorScripts.cc
+++ b/src/scripts/scripts/EditorScripts.cc
@@ -70,7 +70,9 @@ namespace sp::scripts {
                 SceneRef scene;
                 if (lock.Has<ActiveScene>()) {
                     auto &active = lock.Get<ActiveScene>();
-                    scene = active.scene;
+                    if (active.scene && active.scene.data->sceneEntity.Get(lock).Exists(lock)) {
+                        scene = active.scene;
+                    }
                     if (scene) Logf("TraySpawner using editor scene: %s", scene.data->path);
                 }
                 if (!scene) {

--- a/src/scripts/scripts/InteractionScripts.cc
+++ b/src/scripts/scripts/InteractionScripts.cc
@@ -59,7 +59,7 @@ namespace sp::scripts {
                     } else if (std::holds_alternative<bool>(event.data)) {
                         sp::erase(pointEntities, event.source);
                     } else {
-                        Errorf("Unsupported point event type: %s", event.toString());
+                        Errorf("Unsupported point event type: %s", event.ToString());
                     }
                 } else if (event.name == INTERACT_EVENT_INTERACT_GRAB) {
                     if (std::holds_alternative<bool>(event.data)) {
@@ -130,7 +130,7 @@ namespace sp::scripts {
 
                         grabEntities.emplace_back(event.source, secondary);
                     } else {
-                        Errorf("Unsupported grab event type: %s", event.toString());
+                        Errorf("Unsupported grab event type: %s", event.ToString());
                     }
                 } else if (event.name == INTERACT_EVENT_INTERACT_ROTATE) {
                     if (!ent.Has<Physics, PhysicsJoints>(lock) || !enableInteraction) continue;
@@ -257,12 +257,17 @@ namespace sp::scripts {
                         auto justDropped = grabEntity;
                         if (grabEntity) {
                             // Drop the currently held entity
-                            EventBindings::SendEvent(lock, grabEntity, Event{INTERACT_EVENT_INTERACT_GRAB, ent, false});
+                            size_t count = EventBindings::SendEvent(lock,
+                                grabEntity,
+                                Event{INTERACT_EVENT_INTERACT_GRAB, ent, false});
                             UpdateGrabTarget(lock, {});
+                            if (count == 0) {
+                                justDropped = Entity(); // Held entity no longer exists
+                            }
                         }
                         if (std::holds_alternative<bool>(event.data)) {
                             auto &grabEvent = std::get<bool>(event.data);
-                            if (grabEvent && raycastResult.target && raycastResult.target != justDropped) {
+                            if (grabEvent && raycastResult.target && !justDropped) {
                                 // Grab the entity being looked at
                                 if (EventBindings::SendEvent(lock,
                                         raycastResult.target,
@@ -281,7 +286,7 @@ namespace sp::scripts {
                                 }
                             }
                         } else {
-                            Errorf("Unsupported grab event type: %s", event.toString());
+                            Errorf("Unsupported grab event type: %s", event.ToString());
                         }
                     } else if (event.name == INTERACT_EVENT_INTERACT_PRESS) {
                         if (std::holds_alternative<bool>(event.data)) {

--- a/src/scripts/scripts/Magnets.cc
+++ b/src/scripts/scripts/Magnets.cc
@@ -106,7 +106,7 @@ namespace sp::scripts {
 
                         grabEntities.emplace(event.source);
                     } else {
-                        Errorf("Unsupported grab event type: %s", event.toString());
+                        Errorf("Unsupported grab event type: %s", event.ToString());
                     }
                 }
             }

--- a/src/scripts/scripts/PhysicsScripts.cc
+++ b/src/scripts/scripts/PhysicsScripts.cc
@@ -150,7 +150,7 @@ namespace sp::scripts {
                     } else if (std::holds_alternative<EntityRef>(event.data)) {
                         joint.target = std::get<EntityRef>(event.data);
                     } else {
-                        Errorf("Invalid set_target event type: %s", event.toString());
+                        Errorf("Invalid set_target event type: %s", event.ToString());
                         continue;
                     }
                 } else if (action == "set_current_offset") {
@@ -162,7 +162,7 @@ namespace sp::scripts {
                     } else if (std::holds_alternative<EntityRef>(event.data)) {
                         target = std::get<EntityRef>(event.data).Get(lock);
                     } else {
-                        Errorf("Invalid set_current_offset event type: %s", event.toString());
+                        Errorf("Invalid set_current_offset event type: %s", event.ToString());
                         continue;
                     }
                     if (ent.Has<TransformSnapshot>(lock) && target.Has<TransformSnapshot>(lock)) {
@@ -173,14 +173,14 @@ namespace sp::scripts {
                     if (std::holds_alternative<Transform>(event.data)) {
                         joint.localOffset = std::get<Transform>(event.data);
                     } else {
-                        Errorf("Invalid set_local_offset event type: %s", event.toString());
+                        Errorf("Invalid set_local_offset event type: %s", event.ToString());
                         continue;
                     }
                 } else if (action == "set_remote_offset") {
                     if (std::holds_alternative<Transform>(event.data)) {
                         joint.remoteOffset = std::get<Transform>(event.data);
                     } else {
-                        Errorf("Invalid set_remote_offset event type: %s", event.toString());
+                        Errorf("Invalid set_remote_offset event type: %s", event.ToString());
                         continue;
                     }
                 } else {


### PR DESCRIPTION
In this PR:
- Calculates and sends actual force value on collision events
- Updates the duck template to change quack volume based on collision force
- Adds `volume_control` script
- Disables grabbing if already holding an object to prevent grabbing objects behind
- Adds `printgraphics` CFuncfor debugging graphics values
- Adds more objects to the editor tray
- Improve editor to auto-select a spawn scene if not set
- Improves error logging when compiling invalid signal expressions and eliminates some assert crashes