### PR TITLE
Add save game support

### DIFF
--- a/assets/default_input_bindings.json
+++ b/assets/default_input_bindings.json
@@ -79,7 +79,7 @@
             "/keyboard/key/f6": {
                 "outputs": "console:input/action/run_command",
                 "filter": "event",
-                "set_value": "reloadscene; reloadplayer"
+                "set_value": "reloadplayer; reloadscene; respawn"
             },
             "/keyboard/key/f7": {
                 "outputs": "console:input/action/run_command",

--- a/assets/scenes/station-center.json
+++ b/assets/scenes/station-center.json
@@ -46,7 +46,7 @@
 		{
 			"name": "global:spawn",
 			"transform": {
-				"translate": [0, 160.05, -3.8],
+				"translate": [0, 145.05, -3.8],
 				"rotate": [180, 0, 1, 0]
 			}
 		},
@@ -56,8 +56,8 @@
 				"model": "box"
 			},
 			"transform": {
-				"scale": [320, 1, 1],
-				"translate": [0, 160, 3.2]
+				"scale": [290, 1, 1],
+				"translate": [0, 145, 3.2]
 			},
 			"physics": {
 				"shapes": {
@@ -72,8 +72,8 @@
 				"model": "box"
 			},
 			"transform": {
-				"scale": [320, 1, 1],
-				"translate": [0, 160, 3.2],
+				"scale": [290, 1, 1],
+				"translate": [0, 145, 3.2],
 				"rotate": [45, 0, 0, 1]
 			},
 			"physics": {
@@ -90,8 +90,8 @@
 				"visibility": ""
 			},
 			"transform": {
-				"scale": [320, 5.2, 0.1],
-				"translate": [0, 160, 2.75],
+				"scale": [290, 5.2, 0.1],
+				"translate": [0, 145, 2.75],
 				"rotate": [90, 0, 0, 1]
 			},
 			"physics": {
@@ -107,8 +107,8 @@
 				"model": "box"
 			},
 			"transform": {
-				"scale": [5.2, 153.9, 0.1],
-				"translate": [0, 82.95, -2.35]
+				"scale": [5.2, 138.5, 0.1],
+				"translate": [0, 75.25, -2.35]
 			},
 			"physics": {
 				"shapes": {
@@ -123,8 +123,8 @@
 				"model": "box"
 			},
 			"transform": {
-				"scale": [0.1, 160, 5],
-				"translate": [3.05, 86, 0.2]
+				"scale": [0.1, 145, 5],
+				"translate": [3.05, 78.496, 0.2]
 			},
 			"physics": {
 				"shapes": {
@@ -139,8 +139,8 @@
 				"model": "box"
 			},
 			"transform": {
-				"scale": [0.1, 160, 5],
-				"translate": [-3.05, 86, 0.2]
+				"scale": [0.1, 145, 5],
+				"translate": [-3.05, 78.496, 0.2]
 			},
 			"physics": {
 				"shapes": {
@@ -155,8 +155,8 @@
 				"model": "box"
 			},
 			"transform": {
-				"scale": [320, 1, 1],
-				"translate": [0, 160, 3.2],
+				"scale": [290, 1, 1],
+				"translate": [0, 145, 3.2],
 				"rotate": [-45, 0, 0, 1]
 			},
 			"physics": {
@@ -169,7 +169,7 @@
 		{
 			"name": "global:ship_airlock",
 			"transform": {
-				"translate": [0, 160, -3.9]
+				"translate": [0, 145, -3.9]
 			},
 			"scene_connection": {
 				"station-center": "elevator_zone/trigger_player_count"

--- a/assets/scenes/templates/articulating_arm.json
+++ b/assets/scenes/templates/articulating_arm.json
@@ -55,7 +55,7 @@
 					{
 						"outputs": "arm.Arm_0/physics_joint/lock/set_current_offset",
 						"filter": "event",
-						"set_value": "arm.Ball_0"
+						"set_value": "entity:arm.Ball_0"
 					},
 					"arm.Arm_0/physics_joint/lock/enable"
 				]
@@ -111,7 +111,7 @@
 					{
 						"outputs": "arm.Socket_0/physics_joint/lock/set_current_offset",
 						"filter": "event",
-						"set_value": "arm.Ball_0"
+						"set_value": "entity:arm.Ball_0"
 					},
 					"arm.Socket_0/physics_joint/lock/enable"
 				]
@@ -168,7 +168,7 @@
 					{
 						"outputs": "arm.Knob/physics_joint/lock/set_current_offset",
 						"filter": "event",
-						"set_value": "arm.Ball_0"
+						"set_value": "entity:arm.Ball_0"
 					},
 					"arm.Knob/physics_joint/lock/enable"
 				]
@@ -235,7 +235,7 @@
 					{
 						"outputs": "arm.Shaft/physics_joint/lock/set_current_offset",
 						"filter": "event",
-						"set_value": "arm.Ball_0"
+						"set_value": "entity:arm.Ball_0"
 					},
 					"arm.Shaft/physics_joint/lock/enable"
 				]
@@ -289,7 +289,7 @@
 					{
 						"outputs": "arm.Arm_1/physics_joint/lock/set_current_offset",
 						"filter": "event",
-						"set_value": "arm.Ball_0"
+						"set_value": "entity:arm.Ball_0"
 					},
 					"arm.Arm_1/physics_joint/lock/enable"
 				]
@@ -345,7 +345,7 @@
 					{
 						"outputs": "arm.Socket_1/physics_joint/lock/set_current_offset",
 						"filter": "event",
-						"set_value": "arm.Ball_0"
+						"set_value": "entity:arm.Ball_0"
 					},
 					"arm.Socket_1/physics_joint/lock/enable"
 				]
@@ -404,7 +404,7 @@
 					{
 						"outputs": "arm.Ball_1/physics_joint/lock/set_current_offset",
 						"filter": "event",
-						"set_value": "arm.Ball_0"
+						"set_value": "entity:arm.Ball_0"
 					},
 					"arm.Ball_1/physics_joint/lock/enable"
 				]

--- a/assets/scenes/templates/elevator.json
+++ b/assets/scenes/templates/elevator.json
@@ -10,12 +10,12 @@
 			"states": [
 				{
 					"delay": 10,
-					"translate": [0, 160, 0],
+					"translate": [0, 145, 0],
 					"translate_tangent": [0, 0, 0]
 				},
 				{
 					"delay": 10,
-					"translate": [0, 120, 0],
+					"translate": [0, 105, 0],
 					"translate_tangent": [0, -7, 0]
 				},
 				{

--- a/docs/generated/Runtime_Scripts.md
+++ b/docs/generated/Runtime_Scripts.md
@@ -91,6 +91,7 @@ The `component_from_signal` script has parameter type: map&lt;string, [SignalExp
 | **rising_edge** | bool | true | No description |
 | **init_value** | optional&lt;double&gt; | null | No description |
 | **set_event_value** | optional&lt;[SignalExpression](#SignalExpression-type)&gt; | null | No description |
+| **_previous_value** | optional&lt;double&gt; | null | No description |
 
 **See Also:**
 [SignalExpression](#SignalExpression-type)
@@ -166,6 +167,9 @@ The `init_event` script has parameter type: vector&lt;string&gt;
 |------------|------|---------------|-------------|
 | **grab_distance** | float | 2 | No description |
 | **noclip_entity** | [EntityRef](#EntityRef-type) | "" | No description |
+| **_grab_entity** | [EntityRef](#EntityRef-type) | "" | No description |
+| **_point_entity** | [EntityRef](#EntityRef-type) | "" | No description |
+| **_press_entity** | [EntityRef](#EntityRef-type) | "" | No description |
 
 **See Also:**
 [EntityRef](#EntityRef-type)
@@ -181,6 +185,12 @@ The `init_event` script has parameter type: vector&lt;string&gt;
 |------------|------|---------------|-------------|
 | **disabled** | bool | false | No description |
 | **highlight_only** | bool | false | No description |
+| **_grab_entities** | vector&lt;pair&lt;[EntityRef](#EntityRef-type), [EntityRef](#EntityRef-type)&gt;&gt; | [] | No description |
+| **_point_entities** | vector&lt;[EntityRef](#EntityRef-type)&gt; | [] | No description |
+| **_render_outline** | bool | false | No description |
+
+**See Also:**
+[EntityRef](#EntityRef-type)
 
 </div>
 
@@ -309,6 +319,7 @@ The `physics_component_from_signal` script has parameter type: map&lt;string, [S
 | **rising_edge** | bool | true | No description |
 | **init_value** | optional&lt;double&gt; | null | No description |
 | **set_event_value** | optional&lt;[SignalExpression](#SignalExpression-type)&gt; | null | No description |
+| **_previous_value** | optional&lt;double&gt; | null | No description |
 
 **See Also:**
 [SignalExpression](#SignalExpression-type)

--- a/docs/generated/Runtime_Scripts.md
+++ b/docs/generated/Runtime_Scripts.md
@@ -85,7 +85,7 @@ The `component_from_signal` script has parameter type: map&lt;string, [SignalExp
 
 | Parameter Name | Type | Default Value | Description |
 |------------|------|---------------|-------------|
-| **input_expr** | string | "" | No description |
+| **input_expr** | [SignalExpression](#SignalExpression-type) | "" | No description |
 | **output_event** | string | "/script/edge_trigger" | No description |
 | **falling_edge** | bool | true | No description |
 | **rising_edge** | bool | true | No description |
@@ -303,7 +303,7 @@ The `physics_component_from_signal` script has parameter type: map&lt;string, [S
 
 | Parameter Name | Type | Default Value | Description |
 |------------|------|---------------|-------------|
-| **input_expr** | string | "" | No description |
+| **input_expr** | [SignalExpression](#SignalExpression-type) | "" | No description |
 | **output_event** | string | "/script/edge_trigger" | No description |
 | **falling_edge** | bool | true | No description |
 | **rising_edge** | bool | true | No description |

--- a/docs_generator/markdown_gen.hh
+++ b/docs_generator/markdown_gen.hh
@@ -70,6 +70,9 @@ private:
             }
         } else if constexpr (sp::is_vector<T>()) {
             return "vector&lt;" + fieldTypeName<typename T::value_type>() + "&gt;";
+        } else if constexpr (sp::is_pair<T>()) {
+            return "pair&lt;" + fieldTypeName<typename T::first_type>() + ", " +
+                   fieldTypeName<typename T::first_type>() + "&gt;";
         } else if constexpr (sp::json::detail::is_unordered_map<T>()) {
             return "map&lt;" + fieldTypeName<typename T::key_type>() + ", " + fieldTypeName<typename T::mapped_type>() +
                    "&gt;";

--- a/src/common/common/Common.hh
+++ b/src/common/common/Common.hh
@@ -198,9 +198,13 @@ namespace sp {
 
     template<typename T>
     struct is_vector : std::false_type {};
-
     template<typename T>
     struct is_vector<std::vector<T>> : std::true_type {};
+
+    template<typename T>
+    struct is_pair : std::false_type {};
+    template<typename A, typename B>
+    struct is_pair<std::pair<A, B>> : std::true_type {};
 
     template<typename T>
     struct is_optional : std::false_type {};
@@ -214,7 +218,6 @@ namespace sp {
 
     template<typename T>
     struct is_glm_vec : std::false_type {};
-
     template<glm::length_t L, typename T, glm::qualifier Q>
     struct is_glm_vec<glm::vec<L, T, Q>> : std::true_type {};
 

--- a/src/core/assets/AssetManager.cc
+++ b/src/core/assets/AssetManager.cc
@@ -202,11 +202,15 @@ namespace sp {
         }
     }
 
-    bool AssetManager::OutputStream(const std::string &path, std::ofstream &stream) {
-        auto p = OVERRIDE_ASSETS_DIR / path;
-        std::filesystem::create_directories(p.parent_path());
+    bool AssetManager::OutputStream(const std::filesystem::path &path, std::ofstream &stream) {
+        try {
+            std::filesystem::create_directories(path.parent_path());
+        } catch (std::filesystem::filesystem_error &err) {
+            Errorf("Failed to create parent directory: %s", err.what());
+            return false;
+        }
 
-        stream.open(p, std::ios::out | std::ios::binary);
+        stream.open(path, std::ios::out | std::ios::binary);
         return !!stream;
     }
 

--- a/src/core/assets/AssetManager.hh
+++ b/src/core/assets/AssetManager.hh
@@ -30,6 +30,8 @@ namespace sp {
     class PhysicsInfo;
     struct HullSettings;
 
+    extern const std::filesystem::path OVERRIDE_ASSETS_DIR;
+
     enum class AssetType {
         Bundled = 0,
         External,
@@ -56,7 +58,7 @@ namespace sp {
         bool IsGltfRegistered(const std::string &name);
 
         bool InputStream(const std::string &path, AssetType type, std::ifstream &stream, size_t *size = nullptr);
-        bool OutputStream(const std::string &path, std::ofstream &stream);
+        bool OutputStream(const std::filesystem::path &path, std::ofstream &stream);
 
     private:
         void Frame() override;

--- a/src/core/ecs/EventQueue.cc
+++ b/src/core/ecs/EventQueue.cc
@@ -24,7 +24,12 @@ namespace ecs {
         } else if (src.is<double>()) {
             data = src.get<double>();
         } else if (src.is<std::string>()) {
-            data = src.get<std::string>();
+            auto &str = src.get<std::string>();
+            if (str.starts_with("entity:")) {
+                data = EntityRef(Name(str.substr(7), ecs::EntityScope()));
+            } else {
+                data = str;
+            }
         } else if (src.is<picojson::array>()) {
             auto &arr = src.get<picojson::array>();
             if (arr.size() == 2) {
@@ -71,6 +76,13 @@ namespace ecs {
                 sp::json::Save(scope, dst, value);
             },
             src);
+    }
+
+    template<>
+    void StructMetadata::SetScope<EventData>(EventData &dst, const EntityScope &scope) {
+        if (auto *ref = std::get_if<EntityRef>(&dst)) {
+            ref->SetScope(scope);
+        }
     }
 
     std::string Event::ToString() const {

--- a/src/core/ecs/EventQueue.hh
+++ b/src/core/ecs/EventQueue.hh
@@ -45,6 +45,8 @@ namespace ecs {
         picojson::value &dst,
         const EventData &src,
         const EventData *def);
+    template<>
+    void StructMetadata::SetScope<EventData>(EventData &dst, const EntityScope &scope);
 
     struct Event {
         std::string name;

--- a/src/core/ecs/EventQueue.hh
+++ b/src/core/ecs/EventQueue.hh
@@ -87,6 +87,7 @@ namespace ecs {
         static const size_t QUEUE_POOL_BLOCK_SIZE = 1024;
 
         using Ref = std::shared_ptr<EventQueue>;
+        using WeakRef = std::weak_ptr<EventQueue>;
 
         // Returns false if the queue is full
         bool Add(const AsyncEvent &event);
@@ -122,4 +123,12 @@ namespace ecs {
     };
 
     using EventQueueRef = EventQueue::Ref;
+    using EventQueueWeakRef = EventQueue::WeakRef;
 } // namespace ecs
+
+namespace std {
+    // Thread-safe equality check without weak_ptr::lock()
+    inline bool operator==(const ecs::EventQueueRef &a, const ecs::EventQueueWeakRef &b) {
+        return !a.owner_before(b) && !b.owner_before(a);
+    }
+} // namespace std

--- a/src/core/ecs/ScriptManager.cc
+++ b/src/core/ecs/ScriptManager.cc
@@ -132,12 +132,14 @@ namespace ecs {
                     if (!state.eventQueue) state.eventQueue = ecs::EventQueue::New();
                     eventInput.Register(lock, state.eventQueue, event);
                 }
+                entry.first = ent;
             } else if (!state.definition.events.empty()) {
                 Warnf("Script %s has events but %s has no EventInput component",
                     state.definition.name,
                     ecs::ToString(lock, ent));
+            } else {
+                entry.first = ent;
             }
-            entry.first = ent;
         }
     }
 

--- a/src/core/ecs/ScriptManager.hh
+++ b/src/core/ecs/ScriptManager.hh
@@ -32,7 +32,7 @@ namespace ecs {
 
     using PhysicsUpdateLock = Lock<SendEventsLock,
         ReadSignalsLock,
-        Read<TransformSnapshot>,
+        Read<TransformSnapshot, SceneInfo>,
         Write<TransformTree, OpticalElement, Physics, PhysicsJoints, PhysicsQuery, Signals, LaserLine, VoxelArea>>;
 
     using ScriptInitFunc = std::function<void(ScriptState &)>;

--- a/src/core/ecs/SignalExpression.cc
+++ b/src/core/ecs/SignalExpression.cc
@@ -1049,7 +1049,7 @@ namespace ecs {
         picojson::value &dst,
         const SignalExpression &src,
         const SignalExpression *def) {
-        if (src.scope != scope) {
+        if (src.scope != scope && !src.expr.empty()) {
             // TODO: Remap signal names to new scope instead of converting to fully qualified names
             // Warnf("Saving signal expression with missmatched scope: `%s`, scope '%s' != '%s'",
             //     src.expr,

--- a/src/core/ecs/StructFieldTypes.hh
+++ b/src/core/ecs/StructFieldTypes.hh
@@ -82,6 +82,8 @@ namespace ecs {
         std::vector<PhysicsShape>,
         std::vector<ScriptInstance>,
         std::vector<Sound>,
+        std::vector<EntityRef>,
+        std::vector<std::pair<EntityRef, EntityRef>>,
         std::optional<double>,
         std::optional<EventData>,
         std::optional<SignalExpression>,

--- a/src/core/ecs/components/Events.cc
+++ b/src/core/ecs/components/Events.cc
@@ -179,8 +179,9 @@ namespace ecs {
         size_t eventsSent = 0;
         auto it = events.find(event.name);
         if (it != events.end()) {
-            for (auto &queue : it->second) {
-                if (queue->Add(event)) eventsSent++;
+            for (auto &queuePtr : it->second) {
+                auto queue = queuePtr.lock();
+                if (queue && queue->Add(event)) eventsSent++;
             }
         }
         return eventsSent;

--- a/src/core/ecs/components/Events.hh
+++ b/src/core/ecs/components/Events.hh
@@ -41,7 +41,7 @@ namespace ecs {
         size_t Add(const AsyncEvent &event) const;
         static bool Poll(Lock<Read<EventInput>> lock, const EventQueueRef &queue, Event &eventOut);
 
-        robin_hood::unordered_map<std::string, std::vector<EventQueueRef>> events;
+        robin_hood::unordered_map<std::string, std::vector<EventQueueWeakRef>> events;
     };
 
     static Component<EventInput> ComponentEventInput({typeid(EventInput), "event_input", R"(

--- a/src/core/ecs/components/SceneInfo.cc
+++ b/src/core/ecs/components/SceneInfo.cc
@@ -12,8 +12,8 @@
 #include "game/Scene.hh"
 
 namespace ecs {
-    SceneInfo::SceneInfo(Entity ent, const std::shared_ptr<sp::Scene> &scene)
-        : priority(scene->data->priority), scene(scene) {
+    SceneInfo::SceneInfo(Entity ent, const std::shared_ptr<sp::Scene> &scene, const EntityScope &scope)
+        : priority(scene->data->priority), scene(scene), scope(scope) {
         if (IsLive(ent)) {
             liveId = ent;
         } else if (IsStaging(ent)) {

--- a/src/core/ecs/components/SceneInfo.hh
+++ b/src/core/ecs/components/SceneInfo.hh
@@ -15,11 +15,15 @@
 namespace ecs {
     struct SceneInfo {
         SceneInfo() {}
-        SceneInfo(Entity ent, const std::shared_ptr<sp::Scene> &scene);
+        SceneInfo(Entity ent, const std::shared_ptr<sp::Scene> &scene, const EntityScope &scope);
 
-        SceneInfo(Entity rootStagingId, Entity prefabStagingId, size_t prefabScriptId, const SceneInfo &rootSceneInfo)
+        SceneInfo(Entity rootStagingId,
+            Entity prefabStagingId,
+            size_t prefabScriptId,
+            const SceneInfo &rootSceneInfo,
+            const ecs::EntityScope &scope)
             : rootStagingId(rootStagingId), prefabStagingId(prefabStagingId), prefabScriptId(prefabScriptId),
-              priority(rootSceneInfo.priority), scene(rootSceneInfo.scene) {
+              priority(rootSceneInfo.priority), scene(rootSceneInfo.scene), scope(scope) {
             Assertf(IsStaging(rootStagingId), "Invalid rootStagingId in SceneInfo: %s", std::to_string(rootStagingId));
             Assertf(IsStaging(prefabStagingId),
                 "Invalid prefabStagingId in SceneInfo: %s",
@@ -44,5 +48,6 @@ namespace ecs {
 
         sp::ScenePriority priority = sp::ScenePriority::Scene;
         sp::SceneRef scene;
+        EntityScope scope;
     };
 } // namespace ecs

--- a/src/core/game/Scene.hh
+++ b/src/core/game/Scene.hh
@@ -60,14 +60,15 @@ namespace sp {
         // Should only be called from SceneManager thread
         ecs::Entity NewRootEntity(ecs::Lock<ecs::AddRemove> stagingLock,
             const std::shared_ptr<Scene> &scene,
-            ecs::Name name = ecs::Name());
+            ecs::Name name,
+            const ecs::EntityScope &scope);
 
         // Should only be called from SceneManager thread
         ecs::Entity NewPrefabEntity(ecs::Lock<ecs::AddRemove> stagingLock,
             ecs::Entity prefabRoot,
             size_t prefabScriptId,
-            std::string relativeName = "",
-            ecs::EntityScope scope = ecs::Name());
+            std::string relativeName,
+            const ecs::EntityScope &scope);
 
         // Should only be called from SceneManager thread
         void RemovePrefabEntity(ecs::Lock<ecs::AddRemove> stagingLock, ecs::Entity ent);

--- a/src/core/game/SceneRef.hh
+++ b/src/core/game/SceneRef.hh
@@ -26,9 +26,9 @@ namespace sp {
     // Lower priority scenes will have their components overwritten with higher priority components.
     enum class ScenePriority {
         System, // Lowest priority
-        SaveGame,
         Scene,
         Player,
+        SaveGame,
         Bindings,
         Override, // Highest priority
     };

--- a/src/core/game/SceneRef.hh
+++ b/src/core/game/SceneRef.hh
@@ -26,6 +26,7 @@ namespace sp {
     // Lower priority scenes will have their components overwritten with higher priority components.
     enum class ScenePriority {
         System, // Lowest priority
+        SaveGame,
         Scene,
         Player,
         Bindings,

--- a/src/game/DebugCFuncs.cc
+++ b/src/game/DebugCFuncs.cc
@@ -153,9 +153,32 @@ namespace sp {
             });
 
         funcs.Register<std::string>("savegame",
-            "Print out a json serialization of the live scene state",
-            [](std::string outputPath) {
-                GetSceneManager().QueueActionAndBlock(SceneAction::SaveLiveScene, outputPath);
+            "Save a copy of the live scene state to a file",
+            [](std::string saveName) {
+                if (saveName.empty()) {
+                    int i = 0;
+                    while (std::filesystem::exists("./saves/save" + std::to_string(i) + ".json")) {
+                        i++;
+                    }
+                    saveName = "save" + std::to_string(i);
+                }
+                GetSceneManager().QueueActionAndBlock(SceneAction::SaveLiveScene, "saves/" + saveName);
+            });
+
+        funcs.Register<std::string>("loadgame",
+            "Load a previously saved scene state from a file",
+            [](std::string saveName) {
+                if (saveName.empty()) {
+                    int i = 0;
+                    while (std::filesystem::exists("./saves/save" + std::to_string(i + 1) + ".json")) {
+                        i++;
+                    }
+                    saveName = "save" + std::to_string(i);
+                }
+                auto &manager = GetSceneManager();
+                manager.QueueAction(SceneAction::LoadScene, "saves/" + saveName);
+                manager.QueueAction(SceneAction::SyncScene);
+                manager.QueueActionAndBlock(SceneAction::RespawnPlayer);
             });
 
         funcs.Register("printevents", "Print out the current state of event queues", []() {

--- a/src/game/DebugCFuncs.cc
+++ b/src/game/DebugCFuncs.cc
@@ -152,6 +152,12 @@ namespace sp {
                 GetSceneManager().QueueActionAndBlock(SceneAction::SaveStagingScene, sceneName);
             });
 
+        funcs.Register<std::string>("savegame",
+            "Print out a json serialization of the live scene state",
+            [](std::string outputPath) {
+                GetSceneManager().QueueActionAndBlock(SceneAction::SaveLiveScene, outputPath);
+            });
+
         funcs.Register("printevents", "Print out the current state of event queues", []() {
             auto lock = ecs::StartTransaction<
                 ecs::Read<ecs::Name, ecs::SceneInfo, ecs::EventInput, ecs::EventBindings>>();

--- a/src/game/game/CMakeLists.txt
+++ b/src/game/game/CMakeLists.txt
@@ -11,4 +11,5 @@ target_sources(${PROJECT_GAME_LIB} PRIVATE
     GameLogic.cc
     Scene.cc
     SceneManager.cc
+    SceneSaving.cc
 )

--- a/src/game/game/SceneImpl.hh
+++ b/src/game/game/SceneImpl.hh
@@ -201,5 +201,10 @@ namespace sp::scene_util {
                 if (!ref.HasBinding(live)) ref.SetBinding(live, binding);
             }
         }
+
+        if (liveId.Has<Scripts>(live) && !liveId.Has<EventInput>(live)) {
+            auto &scripts = liveId.Get<const Scripts>(live);
+            if (!scripts.scripts.empty()) liveId.Set<EventInput>(live);
+        }
     }
 } // namespace sp::scene_util

--- a/src/game/game/SceneImpl.hh
+++ b/src/game/game/SceneImpl.hh
@@ -14,7 +14,7 @@
 
 #include <bitset>
 
-namespace sp::scene {
+namespace sp::scene_util {
     using namespace ecs;
 
     // Build a flattened set of components from the staging ECS.
@@ -47,7 +47,7 @@ namespace sp::scene {
                     } else if constexpr (std::is_same_v<T, TransformSnapshot>) {
                         // Ignore, this is handled by TransformTree
                     } else if constexpr (std::is_same_v<T, Animation>) {
-                        // Ignore, this is handled bellow and depends on the final TransformTree
+                        // Ignore, this is handled below and depends on the final TransformTree
                     } else if constexpr (std::is_same_v<T, SceneProperties>) {
                         auto &component = std::get<std::shared_ptr<SceneProperties>>(flatEntity);
                         if (!component) {
@@ -156,9 +156,9 @@ namespace sp::scene {
                 } else if constexpr (std::is_same_v<T, SceneInfo>) {
                     // Ignore, this should always be set
                 } else if constexpr (std::is_same_v<T, SignalOutput>) {
-                    // Skip, this is handled bellow
+                    // Skip, this is handled below
                 } else if constexpr (std::is_same_v<T, SignalBindings>) {
-                    // Skip, this is handled bellow
+                    // Skip, this is handled below
                 } else if constexpr (!Tecs::is_global_component<T>()) {
                     auto &component = std::get<std::shared_ptr<T>>(flatEntity);
                     if (component) {
@@ -202,4 +202,4 @@ namespace sp::scene {
             }
         }
     }
-} // namespace sp::scene
+} // namespace sp::scene_util

--- a/src/game/game/SceneManager.cc
+++ b/src/game/game/SceneManager.cc
@@ -700,7 +700,7 @@ namespace sp {
             auto &name_ptr = std::get<std::shared_ptr<ecs::Name>>(flatEnt);
             auto name = name_ptr ? *name_ptr : ecs::Name();
 
-            ecs::Entity entity = scene->NewRootEntity(lock, scene, name);
+            ecs::Entity entity = scene->NewRootEntity(lock, scene, name, scope);
             if (!entity) {
                 // Most llkely a duplicate entity definition
                 Errorf("LoadScene(%s): Failed to create entity, ignoring: '%s'", scenePath, name.String());
@@ -797,7 +797,7 @@ namespace sp {
             auto &name = std::get<std::shared_ptr<ecs::Name>>(flatEnt);
             if (!name || !*name) continue;
 
-            ecs::Entity entity = scene->NewRootEntity(lock, scene, *name);
+            ecs::Entity entity = scene->NewRootEntity(lock, scene, *name, ecs::EntityScope("bindings", ""));
             if (!entity) {
                 // Most llkely a duplicate entity definition
                 Errorf("Failed to create binding entity, ignoring: '%s'", name->String());

--- a/src/game/game/SceneManager.cc
+++ b/src/game/game/SceneManager.cc
@@ -282,9 +282,7 @@ namespace sp {
                         playerScene->RemoveScene(stagingLock, liveLock);
                         playerScene.reset();
                     }
-                    AddScene(item.scenePath, SceneType::Async, [this](auto stagingLock, auto liveLock, auto scene) {
-                        // Maybne pause physics here?
-                    });
+                    AddScene(item.scenePath, SceneType::Async);
 
                     playerScene = LoadSceneJson("player", "system/player", SceneType::World);
                     if (playerScene) {

--- a/src/game/game/SceneManager.hh
+++ b/src/game/game/SceneManager.hh
@@ -104,7 +104,7 @@ namespace sp {
 
         std::shared_ptr<Scene> LoadSceneJson(const std::string &name, const std::string &path, SceneType sceneType);
         void SaveSceneJson(const std::string &name);
-        void SaveLiveSceneJson(const std::string &path);
+        void SaveLiveSceneJson(std::string path);
 
         std::shared_ptr<Scene> LoadBindingsJson();
 

--- a/src/game/game/SceneManager.hh
+++ b/src/game/game/SceneManager.hh
@@ -38,6 +38,7 @@ namespace sp {
         ApplyResetStagingScene, // Arguments: (sceneName, [EditCallback])
         ApplyStagingScene, // Arguments: (sceneName, [EditCallback])
         SaveStagingScene, // Arguments: (sceneName)
+        SaveLiveScene, // Arguments: (outputPath)
         LoadScene, // Arguments: (sceneName)
         ReloadScene, // Arguments: (sceneName)
         AddScene, // Arguments: (sceneName)
@@ -103,6 +104,7 @@ namespace sp {
 
         std::shared_ptr<Scene> LoadSceneJson(const std::string &name, const std::string &path, SceneType sceneType);
         void SaveSceneJson(const std::string &name);
+        void SaveLiveSceneJson(const std::string &path);
 
         std::shared_ptr<Scene> LoadBindingsJson();
 

--- a/src/game/game/SceneSaving.cc
+++ b/src/game/game/SceneSaving.cc
@@ -335,11 +335,11 @@ namespace sp {
         for (auto &scene : scenes[SceneType::Async]) {
             if (!scene || !scene->data || scene->data->priority == ScenePriority::SaveGame) continue;
             // TODO: Add Async scenes with an on-init condition (timer? load-once flag?)
-            connections[scene->data->name] = picojson::value("1");
+            connections[scene->data->path] = picojson::value("1");
         }
         for (auto &scene : scenes[SceneType::World]) {
             if (!scene || !scene->data || scene->data->priority == ScenePriority::SaveGame) continue;
-            connections[scene->data->name] = picojson::value("1");
+            connections[scene->data->path] = picojson::value("1");
         }
         if (!connections.empty()) {
             picojson::object ent;

--- a/src/game/game/SceneSaving.cc
+++ b/src/game/game/SceneSaving.cc
@@ -177,7 +177,7 @@ namespace sp {
                 } else if constexpr (!Tecs::is_global_component<T>()) {
                     const Component<T> &base = LookupComponent<T>();
                     if (src.Has<T>(live)) {
-                        auto &value = components[base.name];
+                        picojson::value &value = components[base.name];
                         auto liveComp = src.Get<T>(live);
                         auto &sceneInfo = src.Get<SceneInfo>(live);
                         std::optional<T> stagingComp = BuildFlatComponent<T>(staging, sceneInfo.rootStagingId);
@@ -332,11 +332,15 @@ namespace sp {
         }
         // Generate scene_connection entity
         picojson::object connections;
-        for (auto &scene : scenes[SceneType::World]) {
-            if (!scene || !scene->data) continue;
+        for (auto &scene : scenes[SceneType::Async]) {
+            if (!scene || !scene->data || scene->data->priority == ScenePriority::SaveGame) continue;
+            // TODO: Add Async scenes with an on-init condition (timer? load-once flag?)
             connections[scene->data->name] = picojson::value("1");
         }
-        // TODO: Add Async scenes with an on-init condition (timer? load-once flag?)
+        for (auto &scene : scenes[SceneType::World]) {
+            if (!scene || !scene->data || scene->data->priority == ScenePriority::SaveGame) continue;
+            connections[scene->data->name] = picojson::value("1");
+        }
         if (!connections.empty()) {
             picojson::object ent;
             ent["scene_connection"] = picojson::value(connections);

--- a/src/game/game/SceneSaving.cc
+++ b/src/game/game/SceneSaving.cc
@@ -1,0 +1,300 @@
+/*
+ * Stray Photons - Copyright (C) 2025 Jacob Wirth
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "assets/Asset.hh"
+#include "assets/AssetManager.hh"
+#include "assets/JsonHelpers.hh"
+#include "common/Common.hh"
+#include "ecs/Components.hh"
+#include "ecs/EcsImpl.hh"
+#include "game/Scene.hh"
+#include "game/SceneImpl.hh"
+#include "game/SceneManager.hh"
+
+#include <fstream>
+#include <picojson/picojson.h>
+
+namespace sp {
+    using namespace ecs;
+
+    bool ComponentOrderFunc(const std::string &a, const std::string &b) {
+        // Sort component keys in the order they are defined in the ECS
+        return GetComponentIndex(a) < GetComponentIndex(b);
+    }
+
+    template<typename T, typename... AllComponentTypes, template<typename...> typename ECSType>
+    std::optional<T> BuildFlatComponent(const Tecs::Lock<ECSType<AllComponentTypes...>, ReadAll> &staging,
+        const Entity &e) {
+        if constexpr (std::is_same_v<T, Name> || std::is_same_v<T, SceneInfo>) {
+            if (e.Has<T>(staging)) {
+                return e.Get<T>(staging);
+            } else {
+                return {};
+            }
+        } else if constexpr (std::is_same_v<T, TransformSnapshot>) {
+            // Ignore, this is handled by TransformTree
+            return {};
+        } else {
+            std::optional<T> flatComp = {};
+            auto stagingId = e;
+            while (stagingId.Has<SceneInfo>(staging)) {
+                auto &stagingInfo = stagingId.Get<SceneInfo>(staging);
+
+                if constexpr (std::is_same_v<T, SceneProperties>) {
+                    if (!flatComp) {
+                        flatComp = LookupComponent<SceneProperties>().StagingDefault();
+                    }
+
+                    Assertf(stagingInfo.scene, "Staging entity %s has null scene", ToString(staging, stagingId));
+                    auto properties = stagingInfo.scene.data->GetProperties(staging);
+                    properties.fixedGravity = properties.rootTransform * glm::vec4(properties.fixedGravity, 0.0f);
+                    properties.gravityTransform = properties.rootTransform * properties.gravityTransform;
+                    LookupComponent<SceneProperties>().ApplyComponent(*flatComp, properties, false);
+                } else if constexpr (!Tecs::is_global_component<T>()) {
+                    if (stagingId.Has<T>(staging)) {
+                        if (!flatComp) {
+                            const ComponentBase *comp = LookupComponent(typeid(T));
+                            Assertf(comp, "Couldn't lookup component type: %s", typeid(T).name());
+                            flatComp = comp->GetStagingDefault<T>();
+                        }
+
+                        if constexpr (std::is_same_v<T, TransformTree> || std::is_same_v<T, Animation>) {
+                            auto transform = stagingId.Get<TransformTree>(staging);
+
+                            if constexpr (std::is_same_v<T, TransformTree>) {
+                                // Apply scene root transform
+                                if (!transform.parent) {
+                                    Assertf(stagingInfo.scene,
+                                        "Staging entity %s has null scene",
+                                        ToString(staging, stagingId));
+                                    auto &properties = stagingInfo.scene.data->GetProperties(staging);
+                                    if (properties.rootTransform != Transform()) {
+                                        transform.pose = properties.rootTransform * transform.pose.Get();
+                                    }
+                                }
+
+                                LookupComponent<TransformTree>().ApplyComponent(*flatComp, transform, false);
+                            } else {
+                                auto animation = stagingId.Get<Animation>(staging);
+
+                                // Apply scene root transform
+                                if (!transform.parent) {
+                                    Assertf(stagingInfo.scene,
+                                        "Staging entity %s has null scene",
+                                        ToString(staging, stagingId));
+                                    auto &properties = stagingInfo.scene.data->GetProperties(staging);
+                                    if (properties.rootTransform != Transform()) {
+                                        for (auto &state : animation.states) {
+                                            state.pos = properties.rootTransform * glm::vec4(state.pos, 1);
+                                        }
+                                    }
+                                }
+
+                                LookupComponent<Animation>().ApplyComponent(*flatComp, animation, false);
+                            }
+                        } else {
+                            auto &srcComp = stagingId.Get<T>(staging);
+                            LookupComponent<T>().ApplyComponent(*flatComp, srcComp, false);
+                        }
+                    }
+                }
+
+                stagingId = stagingInfo.nextStagingId;
+            }
+
+            return flatComp;
+        }
+    }
+
+    template<typename... AllComponentTypes, template<typename...> typename ECSType>
+    bool SaveEntityIfChanged(const Tecs::Lock<ECSType<AllComponentTypes...>, ReadAll> &live,
+        const Lock<ReadAll> &staging,
+        const EntityScope &scope,
+        picojson::value &dst,
+        const Entity &src) {
+        Assertf(IsLive(src), "SaveEntityIfChanged expected source entity to be from live ECS.");
+        picojson::object components(ComponentOrderFunc);
+        ( // For each component:
+            [&] {
+                using T = AllComponentTypes;
+
+                if constexpr (std::is_same_v<T, Name> || std::is_same_v<T, SceneInfo>) {
+                    // Skip
+                } else if constexpr (std::is_same_v<T, SceneProperties> || std::is_same_v<T, TransformSnapshot>) {
+                    // Skip
+                } else if constexpr (std::is_same_v<T, Signals>) {
+                    // TODO: Convert signals to SignalOutput / SignalBindings
+                } else if constexpr (!Tecs::is_global_component<T>()) {
+                    const Component<T> &base = LookupComponent<T>();
+                    if (src.Has<T>(live)) {
+                        auto &value = components[base.name];
+                        auto liveComp = src.Get<T>(live);
+                        auto &sceneInfo = src.Get<SceneInfo>(live);
+                        std::optional<T> stagingComp = BuildFlatComponent<T>(staging, sceneInfo.rootStagingId);
+                        T *compPtr = nullptr;
+                        T flatComp = {};
+                        if (stagingComp) {
+                            base.ApplyComponent(flatComp, *stagingComp, true);
+                            compPtr = &flatComp;
+                        }
+                        if constexpr (std::is_same_v<T, TransformTree>) {
+                            // Special case due to transform override logic
+                            if (liveComp.pose != flatComp.pose || liveComp.parent != flatComp.parent) {
+                                for (const StructField &field : base.metadata.fields) {
+                                    field.Save(scope, value, &liveComp, &base.StagingDefault());
+                                }
+                                StructMetadata::Save<T>(scope, value, liveComp, &base.StagingDefault());
+                            } else {
+                                components.erase(base.name);
+                            }
+                        } else {
+                            for (const StructField &field : base.metadata.fields) {
+                                field.Save(scope, value, &liveComp, compPtr);
+                            }
+                            StructMetadata::Save<T>(scope, value, liveComp, compPtr);
+                            if (value.is<picojson::null>()) {
+                                components.erase(base.name);
+                            }
+                        }
+                    }
+                }
+            }(),
+            ...);
+        if (!components.empty()) {
+            if (src.Has<Name>(live)) {
+                auto &name = src.Get<Name>(live);
+                json::Save(scope, components["name"], name);
+            }
+            dst = picojson::value(components);
+            return true;
+        } else {
+            dst = picojson::value();
+            return false;
+        }
+    }
+
+    void SceneManager::SaveSceneJson(const std::string &sceneName) {
+        auto scene = stagedScenes.Load(sceneName);
+        if (scene) {
+            Tracef("Saving staging scene: %s", scene->data->path);
+            auto staging = StartStagingTransaction<ReadAll>();
+
+            EntityScope scope(scene->data->name, "");
+
+            picojson::array entities;
+            for (auto &e : staging.EntitiesWith<SceneInfo>()) {
+                if (!e.Has<SceneInfo>(staging)) continue;
+                auto &sceneInfo = e.Get<SceneInfo>(staging);
+                // Skip entities that aren't part of this scene, or were created by a prefab script
+                if (sceneInfo.scene != scene || sceneInfo.prefabStagingId) continue;
+
+                picojson::object components(ComponentOrderFunc);
+                if (e.Has<Name>(staging)) {
+                    auto &name = e.Get<Name>(staging);
+                    if (scene->ValidateEntityName(name)) {
+                        json::Save(scope, components["name"], name);
+                    }
+                }
+                ForEachComponent([&](const std::string &name, const ComponentBase &comp) {
+                    if (name == "scene_properties") return;
+                    if (comp.HasComponent(staging, e)) {
+                        auto &value = components[comp.name];
+                        if (comp.metadata.fields.empty() || value.is<picojson::null>()) {
+                            value.set<picojson::object>({});
+                        }
+                        comp.SaveEntity(staging, scope, value, e);
+                    }
+                });
+                entities.emplace_back(components);
+            }
+
+            static auto sceneOrderFunc = [](const std::string &a, const std::string &b) {
+                // Force "entities" to be sorted last
+                if (b == "entities") {
+                    return a < "zentities";
+                } else if (a == "entities") {
+                    return "zentities" < b;
+                } else {
+                    return a < b;
+                }
+            };
+            picojson::object sceneObj(sceneOrderFunc);
+            static const SceneProperties defaultProperties = {};
+            static const ScenePriority defaultPriority = ScenePriority::Scene;
+            json::SaveIfChanged(scope, sceneObj, "properties", scene->data->GetProperties(staging), &defaultProperties);
+            json::SaveIfChanged(scope, sceneObj, "priority", scene->data->priority, &defaultPriority);
+            sceneObj["entities"] = picojson::value(entities);
+            auto val = picojson::value(sceneObj);
+            auto scenePath = scene->asset->path;
+            Logf("Saving scene %s to '%s'", scene->data->name, scenePath.string());
+
+            std::ofstream out;
+            if (Assets().OutputStream(scenePath.string(), out)) {
+                auto outputJson = val.serialize(true);
+                out.write(outputJson.c_str(), outputJson.size());
+                out.close();
+            }
+        } else {
+            Errorf("SceneManager::SaveSceneJson: scene %s not found", sceneName);
+        }
+    }
+
+    void SceneManager::SaveLiveSceneJson(const std::string &outputPath) {
+        Tracef("Saving live scene to: %s", outputPath);
+        auto staging = StartStagingTransaction<ReadAll>();
+        auto live = StartTransaction<ReadAll>();
+
+        EntityScope scope;
+        auto delim = outputPath.rfind('/');
+        if (delim != std::string::npos) {
+            scope.scene = outputPath.substr(delim + 1);
+        } else if (outputPath.empty()) {
+            scope.scene = "save0";
+        } else {
+            scope.scene = outputPath;
+        }
+
+        picojson::array entities;
+        for (auto &e : live.EntitiesWith<SceneInfo>()) {
+            if (!e.Has<SceneInfo>(live)) continue;
+
+            picojson::value ent;
+            if (SaveEntityIfChanged(live, staging, scope, ent, e)) {
+                entities.emplace_back(ent);
+            }
+        }
+        // TODO: Generate scene_connection entity
+        // TODO: Replace player with spawn point entity
+
+        static auto sceneOrderFunc = [](const std::string &a, const std::string &b) {
+            // Force "entities" to be sorted last
+            if (b == "entities") {
+                return a < "zentities";
+            } else if (a == "entities") {
+                return "zentities" < b;
+            } else {
+                return a < b;
+            }
+        };
+        picojson::object sceneObj(sceneOrderFunc);
+        // TODO: Set up scene connections
+        // static const SceneProperties defaultProperties = {};
+        // json::SaveIfChanged(scope, sceneObj, "properties", scene->data->GetProperties(staging), &defaultProperties);
+        json::Save(scope, sceneObj["priority"], ScenePriority::SaveGame);
+        sceneObj["entities"] = picojson::value(entities);
+        auto val = picojson::value(sceneObj);
+        auto scenePath = std::string(outputPath.empty() ? "save0" : outputPath) + ".json";
+        Logf("Saving live scene to '%s'", scenePath);
+
+        std::ofstream out;
+        if (Assets().OutputStream(scenePath, out)) {
+            auto outputJson = val.serialize(true);
+            out.write(outputJson.c_str(), outputJson.size());
+            out.close();
+        }
+    }
+} // namespace sp

--- a/src/graphics/graphics/gui/MenuGuiManager.cc
+++ b/src/graphics/graphics/gui/MenuGuiManager.cc
@@ -361,17 +361,23 @@ namespace sp {
         }
     }
 
+    template<typename TP>
+    std::time_t to_time_t(TP tp) {
+        using namespace std::chrono;
+        auto sctp = time_point_cast<system_clock::duration>(tp - TP::clock::now() + system_clock::now());
+        return system_clock::to_time_t(sctp);
+    }
+
     void MenuGuiManager::RefreshSaveList() {
         saveList.clear();
         int i = 0;
         while (std::filesystem::exists("./saves/save" + std::to_string(i) + ".json")) {
             auto last_write_time = std::filesystem::last_write_time("./saves/save" + std::to_string(i) + ".json");
-            std::time_t time = std::chrono::system_clock::to_time_t(
-                std::chrono::clock_cast<std::chrono::system_clock>(last_write_time));
+            std::time_t time = to_time_t(last_write_time);
             std::tm *tm = std::localtime(&time);
 
             std::string timeStr(100, '\0');
-            size_t n = std::strftime(timeStr.data(), timeStr.size(), "%x %X", tm);
+            size_t n = std::strftime(timeStr.data(), timeStr.size(), "%F %X", tm);
             timeStr.resize(n);
             saveList.emplace_back("Save " + std::to_string(i) + ": " + timeStr, "save" + std::to_string(i));
             i++;

--- a/src/graphics/graphics/gui/MenuGuiManager.hh
+++ b/src/graphics/graphics/gui/MenuGuiManager.hh
@@ -14,7 +14,7 @@ namespace sp {
     class GraphicsManager;
     class GpuTexture;
 
-    enum class MenuScreen { Main, Options, SceneSelect };
+    enum class MenuScreen { Main, Options, SceneSelect, SaveSelect };
 
     class MenuGuiManager : public SystemGuiManager {
     public:
@@ -26,6 +26,7 @@ namespace sp {
 
         bool MenuOpen() const;
         void RefreshSceneList();
+        void RefreshSaveList();
 
     private:
         GraphicsManager &graphics;
@@ -34,6 +35,7 @@ namespace sp {
 
         MenuScreen selectedScreen = MenuScreen::Main;
         std::vector<std::pair<std::string, std::string>> sceneList;
+        std::vector<std::pair<std::string, std::string>> saveList;
 
         shared_ptr<GpuTexture> logoTex;
     };

--- a/src/graphics/graphics/gui/definitions/EditorControls.cc
+++ b/src/graphics/graphics/gui/definitions/EditorControls.cc
@@ -319,7 +319,7 @@ namespace sp {
                 ImGui::Text("Entity: %s", ecs::ToString(lock, this->target).c_str());
 
                 ImGui::AlignTextToFramePadding();
-                ImGui::Text("Entity Definitions:");
+                ImGui::Text("Entity Definitions (Overrides First):");
                 if (targetSceneInfo.prefabStagingId) {
                     ImGui::SameLine(ImGui::GetWindowWidth() - ImGui::GetStyle().FramePadding.x - 200.0f);
                     if (ImGui::Button("Goto Prefab Source", ImVec2(200, 0))) {

--- a/src/graphics/graphics/gui/definitions/EditorControlsImpl.hh
+++ b/src/graphics/graphics/gui/definitions/EditorControlsImpl.hh
@@ -484,7 +484,7 @@ namespace sp {
             liveSceneInfo.scene.data->name);
         auto &stagingInfo = stagingId.Get<ecs::SceneInfo>(staging);
 
-        auto flatParentEntity = scene::BuildEntity(ecs::Lock<ecs::ReadAll>(staging), stagingInfo.nextStagingId);
+        auto flatParentEntity = scene_util::BuildEntity(ecs::Lock<ecs::ReadAll>(staging), stagingInfo.nextStagingId);
         ecs::FlatEntity flatStagingEntity;
 
         ( // For each component:

--- a/src/physics/cooking/ConvexHull.cc
+++ b/src/physics/cooking/ConvexHull.cc
@@ -331,7 +331,7 @@ namespace sp {
         }
 
         std::ofstream out;
-        if (Assets().OutputStream("cache/collision/" + settings->name, out)) {
+        if (Assets().OutputStream(OVERRIDE_ASSETS_DIR / ("cache/collision/" + settings->name), out)) {
             hullCacheHeader header = {};
             header.modelHash = model->asset->Hash();
             HashKey<HullSettings::Fields> settingsHash = {};

--- a/src/scripts/prefabs/GltfPrefab.cc
+++ b/src/scripts/prefabs/GltfPrefab.cc
@@ -71,9 +71,12 @@ namespace ecs {
                     state.GetInstanceId(),
                     getNodeName(nodeId),
                     prefixName);
+                EntityRef newRef(newEntity);
 
                 auto &transform = newEntity.Set<TransformTree>(lock, node.transform);
-                if (parentEnt.Has<TransformTree>(lock)) transform.parent = parentEnt;
+                if (parentEnt.Has<TransformTree>(lock) && parentEnt != newRef) {
+                    transform.parent = parentEnt;
+                }
 
                 if (node.meshIndex) {
                     if (render) {

--- a/src/scripts/prefabs/TemplatePrefab.cc
+++ b/src/scripts/prefabs/TemplatePrefab.cc
@@ -98,7 +98,7 @@ namespace ecs {
                     for (auto &comp : entSrc) {
                         if (comp.first.empty() || comp.first[0] == '_' || comp.first == "name") continue;
 
-                        auto componentType = ecs::LookupComponent(comp.first);
+                        auto componentType = LookupComponent(comp.first);
                         if (componentType != nullptr) {
                             if (!componentType->LoadEntity(entDst.second, comp.second)) {
                                 Errorf("Failed to load component in template (%s), ignoring: %s",
@@ -132,7 +132,7 @@ namespace ecs {
                 for (auto &comp : entSrc) {
                     if (comp.first.empty() || comp.first[0] == '_' || comp.first == "name") continue;
 
-                    auto componentType = ecs::LookupComponent(comp.first);
+                    auto componentType = LookupComponent(comp.first);
                     if (componentType != nullptr) {
                         if (!componentType->LoadEntity(rootComponents, comp.second)) {
                             Errorf("Failed to load component in template (%s), ignoring: %s", sourceName, comp.first);
@@ -150,13 +150,17 @@ namespace ecs {
             ZoneScoped;
 
             Entity newEntity = scene->NewPrefabEntity(lock, rootEnt, prefabScriptId, "scoperoot", scope);
-            ecs::ForEachComponent([&](const std::string &name, const ecs::ComponentBase &comp) {
+            ForEachComponent([&](const std::string &name, const ComponentBase &comp) {
                 comp.SetComponent(lock, scope, newEntity, rootComponents);
             });
+            EntityRef newRef(newEntity);
 
-            if (newEntity.Has<ecs::TransformTree>(lock)) {
-                auto &transform = newEntity.Get<ecs::TransformTree>(lock);
+            if (newEntity.Has<TransformTree>(lock)) {
+                auto &transform = newEntity.Get<TransformTree>(lock);
                 if (!transform.parent) {
+                    if (rootEnt.Has<TransformTree>(lock) && rootEnt != newRef) {
+                        transform.parent = rootEnt;
+                    }
                     transform.pose = offset * transform.pose.Get();
                 }
             }
@@ -167,32 +171,35 @@ namespace ecs {
         void AddEntities(const Lock<AddRemove> &lock, EntityScope scope, Transform offset = {}) {
             ZoneScoped;
 
-            std::vector<ecs::Entity> scriptEntities;
+            std::vector<Entity> scriptEntities;
             for (auto &[relativeName, flatEnt] : entityList) {
-                ecs::Entity newEntity = scene->NewPrefabEntity(lock, rootEnt, prefabScriptId, relativeName, scope);
+                Entity newEntity = scene->NewPrefabEntity(lock, rootEnt, prefabScriptId, relativeName, scope);
                 if (!newEntity) {
                     // Most llkely a duplicate entity or invalid name
                     Errorf("Failed to create template entity (%s), ignoring: '%s'", sourceName, relativeName);
                     continue;
                 }
+                EntityRef newRef(newEntity);
 
-                ecs::ForEachComponent([&](const std::string &name, const ecs::ComponentBase &comp) {
+                ForEachComponent([&](const std::string &name, const ComponentBase &comp) {
                     comp.SetComponent(lock, scope, newEntity, flatEnt);
                 });
 
-                if (newEntity.Has<ecs::TransformTree>(lock)) {
-                    auto &transform = newEntity.Get<ecs::TransformTree>(lock);
+                if (newEntity.Has<TransformTree>(lock)) {
+                    auto &transform = newEntity.Get<TransformTree>(lock);
                     if (!transform.parent) {
-                        if (rootEnt.Has<TransformTree>(lock)) transform.parent = rootEnt;
+                        if (rootEnt.Has<TransformTree>(lock) && rootEnt != newRef) {
+                            transform.parent = rootEnt;
+                        }
                         transform.pose = offset * transform.pose.Get();
                     }
                 }
-                if (newEntity.Has<ecs::Scripts>(lock)) {
+                if (newEntity.Has<Scripts>(lock)) {
                     scriptEntities.push_back(newEntity);
                 }
             }
 
-            auto &scriptManager = ecs::GetScriptManager();
+            auto &scriptManager = GetScriptManager();
             for (auto &e : scriptEntities) {
                 scriptManager.RunPrefabs(lock, e);
             }
@@ -209,7 +216,7 @@ namespace ecs {
             ZoneScoped;
             ZoneStr(source);
 
-            EntityScope scope = ecs::Name(scene->data->name, "");
+            EntityScope scope = Name(scene->data->name, "");
             if (ent.Has<Name>(lock)) scope = ent.Get<Name>(lock);
 
             TemplateParser parser(scene, ent, state.GetInstanceId(), source);
@@ -217,8 +224,8 @@ namespace ecs {
 
             Entity rootOverride = parser.ApplyComponents(lock, scope);
             parser.AddEntities(lock, scope);
-            if (rootOverride.Has<ecs::Scripts>(lock)) {
-                ecs::GetScriptManager().RunPrefabs(lock, rootOverride);
+            if (rootOverride.Has<Scripts>(lock)) {
+                GetScriptManager().RunPrefabs(lock, rootOverride);
             }
         }
     };
@@ -253,7 +260,7 @@ namespace ecs {
                 return;
             }
 
-            EntityScope rootScope = ecs::Name(scene->data->name, "");
+            EntityScope rootScope = Name(scene->data->name, "");
             if (ent.Has<Name>(lock)) rootScope = ent.Get<Name>(lock);
 
             TemplateParser surface(scene, ent, state.GetInstanceId(), surfaceTemplate);
@@ -277,9 +284,9 @@ namespace ecs {
                     offset3D[axesIndex.first] = offset2D.x;
                     offset3D[axesIndex.second] = offset2D.y;
 
-                    ecs::EntityScope tileScope = ecs::Name(std::to_string(x) + "_" + std::to_string(y), rootScope);
+                    EntityScope tileScope = Name(std::to_string(x) + "_" + std::to_string(y), rootScope);
 
-                    ecs::Entity tileEnt = surface.ApplyComponents(lock, tileScope, offset3D);
+                    Entity tileEnt = surface.ApplyComponents(lock, tileScope, offset3D);
                     if (!tileEnt) {
                         // Most llkely a duplicate entity or invalid name
                         Errorf("Failed to create tiled template entity (%s), ignoring: '%s'",
@@ -325,8 +332,8 @@ namespace ecs {
                             edge.AddEntities(lock, tileScope, transform);
                         }
                     }
-                    if (tileEnt.Has<ecs::Scripts>(lock)) {
-                        ecs::GetScriptManager().RunPrefabs(lock, tileEnt);
+                    if (tileEnt.Has<Scripts>(lock)) {
+                        GetScriptManager().RunPrefabs(lock, tileEnt);
                     }
                 }
             }

--- a/src/scripts/prefabs/TemplatePrefab.cc
+++ b/src/scripts/prefabs/TemplatePrefab.cc
@@ -157,7 +157,6 @@ namespace ecs {
             if (newEntity.Has<ecs::TransformTree>(lock)) {
                 auto &transform = newEntity.Get<ecs::TransformTree>(lock);
                 if (!transform.parent) {
-                    if (rootEnt.Has<TransformTree>(lock)) transform.parent = rootEnt;
                     transform.pose = offset * transform.pose.Get();
                 }
             }

--- a/src/scripts/scripts/EditorScripts.cc
+++ b/src/scripts/scripts/EditorScripts.cc
@@ -102,7 +102,7 @@ namespace sp::scripts {
                         }
                         Logf("TraySpawner new entity: %s", name.String());
 
-                        auto newEntity = scene->NewRootEntity(lock, scene, name);
+                        auto newEntity = scene->NewRootEntity(lock, scene, name, scope);
                         newEntity.Set<TransformTree>(lock, transform);
                         if (signalOutputs) {
                             newEntity.Set<SignalOutput>(lock, *signalOutputs);

--- a/src/scripts/scripts/MiscScripts.cc
+++ b/src/scripts/scripts/MiscScripts.cc
@@ -31,7 +31,6 @@ namespace sp::scripts {
         std::optional<SignalExpression> eventValue;
 
         // Internal script state
-        std::string lastExpr;
         std::optional<double> previousValue;
 
         template<typename LockType>
@@ -71,7 +70,8 @@ namespace sp::scripts {
         StructField::New("falling_edge", &EdgeTrigger::enableFalling),
         StructField::New("rising_edge", &EdgeTrigger::enableRising),
         StructField::New("init_value", &EdgeTrigger::previousValue),
-        StructField::New("set_event_value", &EdgeTrigger::eventValue));
+        StructField::New("set_event_value", &EdgeTrigger::eventValue),
+        StructField::New("_previous_value", &EdgeTrigger::previousValue));
     InternalScript<EdgeTrigger> edgeTrigger("edge_trigger", MetadataEdgeTrigger);
     InternalPhysicsScript<EdgeTrigger> physicsEdgeTrigger("physics_edge_trigger", MetadataEdgeTrigger);
 

--- a/src/scripts/scripts/MiscScripts.cc
+++ b/src/scripts/scripts/MiscScripts.cc
@@ -23,7 +23,7 @@ namespace sp::scripts {
 
     struct EdgeTrigger {
         // Input parameters
-        std::string inputExpr;
+        SignalExpression inputExpr;
         std::string outputName = "/script/edge_trigger";
 
         bool enableFalling = true;
@@ -31,17 +31,13 @@ namespace sp::scripts {
         std::optional<SignalExpression> eventValue;
 
         // Internal script state
-        SignalExpression expr;
+        std::string lastExpr;
         std::optional<double> previousValue;
 
         template<typename LockType>
         void updateEdgeTrigger(ScriptState &state, const LockType &lock, const Entity &ent) {
-            if (expr.expr != inputExpr || state.scope != expr.scope) {
-                expr = SignalExpression(inputExpr, state.scope);
-                if (!previousValue) previousValue = expr.Evaluate(lock);
-            }
-
-            auto value = expr.Evaluate(lock);
+            auto value = inputExpr.Evaluate(lock);
+            if (!previousValue) previousValue = value;
 
             Event outputEvent;
             outputEvent.name = outputName;

--- a/src/scripts/scripts/PhysicsScripts.cc
+++ b/src/scripts/scripts/PhysicsScripts.cc
@@ -159,8 +159,15 @@ namespace sp::scripts {
                     if (std::holds_alternative<std::string>(event.data)) {
                         auto targetName = std::get<std::string>(event.data);
                         target = ecs::EntityRef(ecs::Name(targetName, state.scope)).Get(lock);
+                        if (!target) {
+                            Errorf("Invalid set_current_offset event target: %s", targetName);
+                        }
                     } else if (std::holds_alternative<EntityRef>(event.data)) {
-                        target = std::get<EntityRef>(event.data).Get(lock);
+                        auto targetRef = std::get<EntityRef>(event.data);
+                        target = targetRef.Get(lock);
+                        if (!target) {
+                            Errorf("Invalid set_current_offset event target: %s", targetRef.Name().String());
+                        }
                     } else {
                         Errorf("Invalid set_current_offset event type: %s", event.ToString());
                         continue;

--- a/tests/integration/scene-manager.cc
+++ b/tests/integration/scene-manager.cc
@@ -71,7 +71,7 @@ namespace SceneManagerTests {
     void systemSceneCallback(ecs::Lock<ecs::AddRemove> lock, std::shared_ptr<sp::Scene> scene) {
         auto ent = lock.NewEntity();
         ent.Set<ecs::Name>(lock, "player", "player");
-        ent.Set<ecs::SceneInfo>(lock, ent, scene);
+        ent.Set<ecs::SceneInfo>(lock, ent, scene, ecs::EntityScope("player", ""));
         ent.Set<ecs::TransformSnapshot>(lock, ecs::Transform(glm::vec3(1, 2, 3)));
         ent.Set<ecs::EventInput>(lock);
         ent.Set<ecs::EventBindings>(lock);
@@ -79,7 +79,7 @@ namespace SceneManagerTests {
 
         ent = lock.NewEntity();
         ent.Set<ecs::Name>(lock, "", "test");
-        ent.Set<ecs::SceneInfo>(lock, ent, scene);
+        ent.Set<ecs::SceneInfo>(lock, ent, scene, ecs::EntityScope());
     }
 
     void TestBasicLoadAddRemove() {


### PR DESCRIPTION
- Adds the `savegame` and `loadgame` console commands
- - `savegame` writes to `saves/save<N>.json` for the next available number
- - `loadgame` loads the highest number save in `saves/`
- Adds a Save Game menu option and Load Game selection menu
- Tweaks the `station-center` scene connection point so the gravity in the menu airlock is slightly down.
- New `"entity:"` prefix in scene json to store EntityRefs
- Changes `EventInput` to store weak references to event queues
- Automatically create `EventInput` for entities with `Scripts`
- Separates `printevents` into `printbindings` command
- Stores entity scope in `SceneInfo`
- Bug fixes for serializing, SetScope, and script state perservation