### PR TITLE
Add signal debugger to editor panel

### DIFF
--- a/src/core/ecs/SignalExpressionNode.hh
+++ b/src/core/ecs/SignalExpressionNode.hh
@@ -118,7 +118,7 @@ namespace ecs {
             std::string text;
             CompiledFunc evaluate = nullptr;
             sp::InlineVector<SignalNodePtr, 3> childNodes;
-            std::vector<WeakNodePtr> dependencies;
+            std::vector<WeakNodePtr> references;
             bool uncacheable = false;
 
             template<typename T>
@@ -131,8 +131,9 @@ namespace ecs {
                 }
             }
 
-            static const SignalNodePtr &UpdateDependencies(const SignalNodePtr &node);
-            void PropagateUncacheable(bool newUncacheable);
+            static const SignalNodePtr &AddReferences(const SignalNodePtr &node);
+            // Returns true if uncacheable changed
+            bool PropagateUncacheable(bool newUncacheable);
 
             CompiledFunc Compile();
             void SubscribeToChildren(const Lock<Write<Signals>> &lock, const SignalRef &subscriber) const;

--- a/src/core/ecs/SignalManager.cc
+++ b/src/core/ecs/SignalManager.cc
@@ -134,13 +134,14 @@ namespace ecs {
         });
         if (!refsToFree.empty()) {
             ZoneScopedN("FreeSignals");
-            ecs::QueueTransaction<ecs::Write<ecs::Signals>>([refsToFree](auto &lock) {
-                auto &signals = lock.Get<Signals>();
-                for (auto &refPtr : refsToFree) {
-                    signals.FreeSignal(lock, refPtr->index);
-                    refPtr->index = std::numeric_limits<size_t>::max();
-                }
-            });
+            ecs::QueueTransaction<ecs::Write<ecs::Signals>>(
+                [refsToFree](const ecs::Lock<ecs::Write<ecs::Signals>> &lock) {
+                    auto &signals = lock.Get<Signals>();
+                    for (auto &refPtr : refsToFree) {
+                        signals.FreeSignal(lock, refPtr->index);
+                        refPtr->index = std::numeric_limits<size_t>::max();
+                    }
+                });
         }
         return refsToFree.size();
     }

--- a/src/core/ecs/SignalManager.cc
+++ b/src/core/ecs/SignalManager.cc
@@ -79,7 +79,7 @@ namespace ecs {
     }
 
     SignalNodePtr SignalManager::GetNode(const Node &node) {
-        return Node::UpdateDependencies(signalNodes.LoadOrInsert(node));
+        return Node::AddReferences(signalNodes.LoadOrInsert(node));
     }
 
     SignalNodePtr SignalManager::GetConstantNode(double value) {
@@ -125,6 +125,24 @@ namespace ecs {
 
     size_t SignalManager::DropAllUnusedNodes() {
         return signalNodes.DropAll();
+    }
+
+    size_t SignalManager::DropAllUnusedRefs() {
+        std::vector<std::shared_ptr<SignalRef::Ref>> refsToFree;
+        signalRefs.DropAll([&](std::shared_ptr<SignalRef::Ref> &refPtr) {
+            refsToFree.emplace_back(refPtr);
+        });
+        if (!refsToFree.empty()) {
+            ZoneScopedN("FreeSignals");
+            ecs::QueueTransaction<ecs::Write<ecs::Signals>>([refsToFree](auto &lock) {
+                auto &signals = lock.Get<Signals>();
+                for (auto &refPtr : refsToFree) {
+                    signals.FreeSignal(lock, refPtr->index);
+                    refPtr->index = std::numeric_limits<size_t>::max();
+                }
+            });
+        }
+        return refsToFree.size();
     }
 
     size_t SignalManager::GetNodeCount() {

--- a/src/core/ecs/SignalManager.hh
+++ b/src/core/ecs/SignalManager.hh
@@ -42,6 +42,7 @@ namespace ecs {
 
         void Tick(chrono_clock::duration maxTickInterval);
         size_t DropAllUnusedNodes();
+        size_t DropAllUnusedRefs();
         size_t GetNodeCount();
 
     private:

--- a/src/core/ecs/SignalRef.hh
+++ b/src/core/ecs/SignalRef.hh
@@ -46,6 +46,7 @@ namespace ecs {
         void AddSubscriber(const Lock<Write<Signals>> &lock, const SignalRef &ref) const;
         void MarkDirty(const Lock<Write<Signals>> &lock, size_t depth = 0) const;
         bool IsCacheable(const Lock<Read<Signals>> &lock) const;
+        void RefreshUncacheable(const Lock<Write<Signals>> &lock) const;
         void UpdateDirtySubscribers(const DynamicLock<Write<Signals>, ReadSignalsLock> &lock, size_t depth = 0) const;
 
         double &SetValue(const Lock<Write<Signals>> &lock, double value) const;

--- a/src/game/DebugCFuncs.cc
+++ b/src/game/DebugCFuncs.cc
@@ -232,7 +232,7 @@ namespace sp {
         funcs.Register<std::string>("printsignals",
             "Print out the values and bindings of signals (optionally filtered by argument)",
             [](std::string filterStr) {
-                auto lock = ecs::StartTransaction<ecs::ReadSignalsLock>();
+                auto lock = ecs::StartTransaction<ecs::ReadAll>();
                 if (filterStr.empty()) {
                     Logf("Signals:");
                 } else {
@@ -257,7 +257,7 @@ namespace sp {
         funcs.Register<std::string>("printsignal",
             "Print out the value and bindings of a specific signal",
             [](std::string signalStr) {
-                auto lock = ecs::StartTransaction<ecs::ReadSignalsLock>();
+                auto lock = ecs::StartTransaction<ecs::ReadAll>();
 
                 ecs::SignalRef signal(signalStr);
                 if (!signal) {

--- a/src/game/game/Game.hh
+++ b/src/game/game/Game.hh
@@ -61,11 +61,12 @@ namespace sp {
     public:
         LockFreeEventQueue<ecs::Event> inputEventQueue;
 
+        std::shared_ptr<xr::XrSystem> xr;
+        bool enableXrSystem = false;
+
         std::shared_ptr<GraphicsManager> graphics;
         std::shared_ptr<PhysxManager> physics;
         std::shared_ptr<AudioManager> audio;
-        std::shared_ptr<xr::XrSystem> xr;
-        bool enableXrSystem = false;
 
         ConsoleBindingManager consoleBinding;
         EditorSystem editor;

--- a/src/graphics/graphics/gui/SystemGuiManager.cc
+++ b/src/graphics/graphics/gui/SystemGuiManager.cc
@@ -56,20 +56,44 @@ namespace sp {
             ecs::Event event;
             while (ecs::EventInput::Poll(lock, events, event)) {
                 if (event.name == INPUT_EVENT_MENU_SCROLL) {
+                    if (!std::holds_alternative<glm::vec2>(event.data)) {
+                        Warnf("System GUI received unexpected event data: %s, expected vec2", event.ToString());
+                        continue;
+                    }
                     auto &scroll = std::get<glm::vec2>(event.data);
                     io.AddMouseWheelEvent(scroll.x, scroll.y);
                 } else if (event.name == INPUT_EVENT_MENU_CURSOR) {
+                    if (!std::holds_alternative<glm::vec2>(event.data)) {
+                        Warnf("System GUI received unexpected event data: %s, expected vec2", event.ToString());
+                        continue;
+                    }
                     auto &pos = std::get<glm::vec2>(event.data);
                     io.AddMousePosEvent(pos.x / io.DisplayFramebufferScale.x, pos.y / io.DisplayFramebufferScale.y);
                 } else if (event.name == INPUT_EVENT_MENU_PRIMARY_TRIGGER) {
+                    if (!std::holds_alternative<bool>(event.data)) {
+                        Warnf("System GUI received unexpected event data: %s, expected bool", event.ToString());
+                        continue;
+                    }
                     auto &down = std::get<bool>(event.data);
                     io.AddMouseButtonEvent(ImGuiMouseButton_Left, down);
                 } else if (event.name == INPUT_EVENT_MENU_SECONDARY_TRIGGER) {
+                    if (!std::holds_alternative<bool>(event.data)) {
+                        Warnf("System GUI received unexpected event data: %s, expected bool", event.ToString());
+                        continue;
+                    }
                     auto &down = std::get<bool>(event.data);
                     io.AddMouseButtonEvent(ImGuiMouseButton_Right, down);
                 } else if (event.name == INPUT_EVENT_MENU_TEXT_INPUT) {
+                    if (!std::holds_alternative<unsigned int>(event.data)) {
+                        Warnf("System GUI received unexpected event data: %s, expected uint", event.ToString());
+                        continue;
+                    }
                     io.AddInputCharacter(std::get<unsigned int>(event.data));
                 } else if (event.name == INPUT_EVENT_MENU_KEY_DOWN) {
+                    if (!std::holds_alternative<int>(event.data)) {
+                        Warnf("System GUI received unexpected event data: %s, expected int", event.ToString());
+                        continue;
+                    }
                     auto &keyCode = (KeyCode &)std::get<int>(event.data);
                     if (keyCode == KEY_LEFT_CONTROL || keyCode == KEY_RIGHT_CONTROL) {
                         io.AddKeyEvent(ImGuiMod_Ctrl, true);
@@ -85,6 +109,10 @@ namespace sp {
                         io.AddKeyEvent(imguiKey->second, true);
                     }
                 } else if (event.name == INPUT_EVENT_MENU_KEY_UP) {
+                    if (!std::holds_alternative<int>(event.data)) {
+                        Warnf("System GUI received unexpected event data: %s, expected int", event.ToString());
+                        continue;
+                    }
                     auto &keyCode = (KeyCode &)std::get<int>(event.data);
                     if (keyCode == KEY_LEFT_CONTROL || keyCode == KEY_RIGHT_CONTROL) {
                         io.AddKeyEvent(ImGuiMod_Ctrl, false);

--- a/src/graphics/graphics/gui/WorldGuiManager.cc
+++ b/src/graphics/graphics/gui/WorldGuiManager.cc
@@ -90,13 +90,18 @@ namespace sp {
                         } else {
                             pointingStack.emplace_back(PointingState{event.source, mousePos});
                         }
-                    } else if (existingState != pointingStack.end()) {
-                        if (existingState->mouseDown) {
-                            // Keep state if mouse was dragged off screen
-                            existingState->mousePos = {-FLT_MAX, -FLT_MAX};
-                        } else {
-                            pointingStack.erase(existingState);
+                    } else if (std::holds_alternative<bool>(event.data)) {
+                        if (existingState != pointingStack.end()) {
+                            if (existingState->mouseDown) {
+                                // Keep state if mouse was dragged off screen
+                                existingState->mousePos = {-FLT_MAX, -FLT_MAX};
+                            } else {
+                                pointingStack.erase(existingState);
+                            }
                         }
+                    } else {
+                        Warnf("World GUI received unexpected event data: %s, expected Transform, vec2, or bool",
+                            event.ToString());
                     }
                 } else if (event.name == INTERACT_EVENT_INTERACT_PRESS) {
                     if (std::holds_alternative<bool>(event.data)) {
@@ -117,6 +122,9 @@ namespace sp {
                                 std::to_string(event.source),
                                 guiEntity.Name().String());
                         }
+                    } else {
+                        Warnf("World GUI received unexpected event data: %s, expected bool", event.ToString());
+                        continue;
                     }
                 }
             }

--- a/src/graphics/graphics/gui/definitions/EditorControls.cc
+++ b/src/graphics/graphics/gui/definitions/EditorControls.cc
@@ -557,9 +557,9 @@ namespace sp {
                 auto node = ecs::GetSignalManager().FindSignalNode(ref);
                 if (node) {
                     ImGui::Text("Node cacheable: %s", node->uncacheable ? "false" : "true");
-                    ImGui::Text("Node references: %u", node->references.size());
+                    ImGui::Text("Node references: %llu", node->references.size());
                 }
-                ImGui::Text("Subscribers: %u", signal.subscribers.size());
+                ImGui::Text("Subscribers: %llu", signal.subscribers.size());
                 for (auto &sub : signal.subscribers) {
                     auto subscriber = ecs::SignalRef(sub.lock());
                     if (subscriber) {
@@ -569,7 +569,7 @@ namespace sp {
                         }
                     }
                 }
-                ImGui::Text("Dependencies: %u", signal.dependencies.size());
+                ImGui::Text("Dependencies: %llu", signal.dependencies.size());
                 for (auto &dep : signal.dependencies) {
                     auto dependency = ecs::SignalRef(dep.lock());
                     if (dependency) {

--- a/src/graphics/graphics/gui/definitions/EditorControls.cc
+++ b/src/graphics/graphics/gui/definitions/EditorControls.cc
@@ -508,4 +508,78 @@ namespace sp {
             }
         }
     }
+
+    void EditorContext::ShowSignalControls(const ecs::Lock<ecs::ReadAll> &lock) {
+        ImGui::Text("Signal References:");
+        ImGui::InputTextWithHint("##signal_search", "Signal Search", &signalSearch);
+        if (ImGui::BeginListBox("##SignalRefs", ImVec2(-FLT_MIN, 10.25 * ImGui::GetTextLineHeightWithSpacing()))) {
+            auto refList = ecs::GetSignalManager().GetSignals(signalSearch);
+            for (auto &entry : refList) {
+                std::string text = entry.String();
+                // + " (" + std::string(magic_enum::enum_name(entry.data->type)) + ")";
+                if (ImGui::Selectable(text.c_str(), entry == this->selectedSignal)) {
+                    this->selectedSignal = entry;
+                }
+            }
+            ImGui::EndListBox();
+        }
+        if (ImGui::Button("Drop Unused")) {
+            ecs::GetSignalManager().DropAllUnusedRefs();
+        }
+        ImGui::Separator();
+        if (this->selectedSignal) {
+            ImGui::AlignTextToFramePadding();
+            auto &ref = this->selectedSignal;
+            std::string text = ref.String();
+            ImGui::Text("Signal: %s", text.c_str());
+            if (ref.HasValue(lock)) {
+                ImGui::Text("Value = %.4f", ref.GetValue(lock));
+            } else if (!ref.HasBinding(lock)) {
+                ImGui::Text("Value = 0.0 (unset)");
+            }
+            if (ref.HasBinding(lock)) {
+                auto &binding = ref.GetBinding(lock);
+                ImGui::Text("Binding%s: %s", ref.HasValue(lock) ? " (overriden by value)" : "", binding.expr.c_str());
+                if (binding.rootNode->text != binding.expr) {
+                    ImGui::Text("Binding node: %s", binding.rootNode->text.c_str());
+                }
+                ImGui::Text("Binding eval = %.4f", binding.Evaluate(lock));
+            }
+            auto &signals = lock.Get<ecs::Signals>().signals;
+            auto &index = ref.GetIndex();
+            if (index < signals.size()) {
+                auto &signal = signals[index];
+                if (ref.IsCacheable(lock)) {
+                    ImGui::Text("Cached value: %.4f %s", signal.lastValue, signal.lastValueDirty ? " (dirty)" : "");
+                } else {
+                    ImGui::Text("Signal uncacheable");
+                }
+                auto node = ecs::GetSignalManager().FindSignalNode(ref);
+                if (node) {
+                    ImGui::Text("Node cacheable: %s", node->uncacheable ? "false" : "true");
+                    ImGui::Text("Node references: %u", node->references.size());
+                }
+                ImGui::Text("Subscribers: %u", signal.subscribers.size());
+                for (auto &sub : signal.subscribers) {
+                    auto subscriber = ecs::SignalRef(sub.lock());
+                    if (subscriber) {
+                        text = subscriber.String();
+                        if (ImGui::Button(text.c_str())) {
+                            this->selectedSignal = subscriber;
+                        }
+                    }
+                }
+                ImGui::Text("Dependencies: %u", signal.dependencies.size());
+                for (auto &dep : signal.dependencies) {
+                    auto dependency = ecs::SignalRef(dep.lock());
+                    if (dependency) {
+                        text = dependency.String();
+                        if (ImGui::Button(text.c_str())) {
+                            this->selectedSignal = dependency;
+                        }
+                    }
+                }
+            }
+        }
+    }
 } // namespace sp

--- a/src/graphics/graphics/gui/definitions/EditorControls.cc
+++ b/src/graphics/graphics/gui/definitions/EditorControls.cc
@@ -557,9 +557,9 @@ namespace sp {
                 auto node = ecs::GetSignalManager().FindSignalNode(ref);
                 if (node) {
                     ImGui::Text("Node cacheable: %s", node->uncacheable ? "false" : "true");
-                    ImGui::Text("Node references: %llu", node->references.size());
+                    ImGui::Text("Node references: %lu", node->references.size());
                 }
-                ImGui::Text("Subscribers: %llu", signal.subscribers.size());
+                ImGui::Text("Subscribers: %lu", signal.subscribers.size());
                 for (auto &sub : signal.subscribers) {
                     auto subscriber = ecs::SignalRef(sub.lock());
                     if (subscriber) {
@@ -569,7 +569,7 @@ namespace sp {
                         }
                     }
                 }
-                ImGui::Text("Dependencies: %llu", signal.dependencies.size());
+                ImGui::Text("Dependencies: %lu", signal.dependencies.size());
                 for (auto &dep : signal.dependencies) {
                     auto dependency = ecs::SignalRef(dep.lock());
                     if (dependency) {

--- a/src/graphics/graphics/gui/definitions/EditorControls.hh
+++ b/src/graphics/graphics/gui/definitions/EditorControls.hh
@@ -17,10 +17,11 @@ namespace sp {
         };
 
         // Persistent context
-        std::string entitySearch, sceneEntry;
+        std::string entitySearch, sceneEntry, signalSearch;
         std::map<ecs::Name, TreeNode> entityTree;
         ecs::EntityRef inspectorEntity = ecs::Name("editor", "inspector");
         SceneRef scene;
+        ecs::SignalRef selectedSignal;
         ecs::Entity target;
         std::string followFocus;
         int followFocusPos;
@@ -36,6 +37,7 @@ namespace sp {
         void AddLiveSignalControls(const ecs::Lock<ecs::ReadAll> &lock, const ecs::EntityRef &targetEntity);
         void ShowEntityControls(const ecs::Lock<ecs::ReadAll> &lock, const ecs::EntityRef &targetEntity);
         void ShowSceneControls(const ecs::Lock<ecs::ReadAll> &lock);
+        void ShowSignalControls(const ecs::Lock<ecs::ReadAll> &lock);
 
         template<typename T>
         bool AddImGuiElement(const std::string &name, T &value);

--- a/src/graphics/graphics/gui/definitions/InspectorGui.cc
+++ b/src/graphics/graphics/gui/definitions/InspectorGui.cc
@@ -60,12 +60,12 @@ namespace sp {
             while (ecs::EventInput::Poll(lock, events, event)) {
                 if (event.name != EDITOR_EVENT_EDIT_TARGET) continue;
 
-                if (!std::holds_alternative<ecs::Entity>(event.data)) {
-                    Errorf("Invalid editor event: %s", event.ToString());
-                } else {
+                if (std::holds_alternative<ecs::Entity>(event.data)) {
                     auto newTarget = std::get<ecs::Entity>(event.data);
                     targetEntity = newTarget;
                     if (newTarget && ecs::IsStaging(newTarget)) selectEntityView = true;
+                } else {
+                    Errorf("Invalid editor event: %s", event.ToString());
                 }
             }
 
@@ -121,6 +121,11 @@ namespace sp {
             if (ImGui::BeginTabItem("Scene View")) {
                 auto stagingLock = ecs::StartStagingTransaction<ecs::ReadAll>();
                 context->ShowSceneControls(stagingLock);
+                ImGui::EndTabItem();
+            }
+            if (ImGui::BeginTabItem("Signal Debugger")) {
+                auto liveLock = ecs::StartTransaction<ecs::ReadAll>();
+                context->ShowSignalControls(liveLock);
                 ImGui::EndTabItem();
             }
             ImGui::EndTabBar();


### PR DESCRIPTION
As part of fixing some `uncacheable` flag propagation issues, this PR adds a new panel to the editor UI.