### PR TITLE
Bind shader inputs by name instead of index

### DIFF
--- a/shaders/vulkan/voxel_merge_layer.comp
+++ b/shaders/vulkan/voxel_merge_layer.comp
@@ -12,7 +12,7 @@ layout(local_size_x = 16, local_size_y = 16) in;
 #include "../lib/types_common.glsl"
 #include "../lib/voxel_shared.glsl"
 
-layout(binding = 0) uniform G_VoxelState {
+layout(binding = 0) uniform VoxelStateUniform {
     VoxelState voxelInfo;
 };
 

--- a/src/graphics/graphics/vulkan/Renderer.cc
+++ b/src/graphics/graphics/vulkan/Renderer.cc
@@ -232,7 +232,6 @@ namespace sp::vulkan {
             .Execute([this, sourceID](rg::Resources &resources, CommandContext &cmd) {
                 if (sourceID != rg::InvalidResource) {
                     auto source = resources.GetImageView(sourceID);
-                    cmd.SetImageView(0, 0, source);
                     cmd.DrawScreenCover(source);
                 }
 
@@ -296,7 +295,7 @@ namespace sp::vulkan {
                 GPUViewState viewState[] = {{view}, {}};
                 auto viewStateBuf = resources.GetBuffer("ViewState");
                 viewStateBuf->CopyFrom(viewState, 2);
-                cmd.SetUniformBuffer(0, 10, viewStateBuf);
+                cmd.SetUniformBuffer("ViewStates", viewStateBuf);
 
                 scene.DrawSceneIndirect(cmd,
                     resources.GetBuffer("WarpedVertexBuffer"),
@@ -429,7 +428,7 @@ namespace sp::vulkan {
                 cmd.SetStencilReference(vk::StencilFaceFlagBits::eFrontAndBack, 1);
 
                 auto viewStateBuf = resources.GetBuffer("ViewState");
-                cmd.SetUniformBuffer(0, 10, viewStateBuf);
+                cmd.SetUniformBuffer("ViewStates", viewStateBuf);
 
                 scene.DrawSceneIndirect(cmd,
                     resources.GetBuffer("WarpedVertexBuffer"),

--- a/src/graphics/graphics/vulkan/core/CommandContext.cc
+++ b/src/graphics/graphics/vulkan/core/CommandContext.cc
@@ -493,7 +493,7 @@ namespace sp::vulkan {
         vk::DeviceSize offset,
         vk::DeviceSize range) {
         Assert(resources, "Render Graph resources not set on CommandContext");
-        SetUniformBuffer(bindingName, resources->GetBuffer(resourceName));
+        SetUniformBuffer(bindingName, resources->GetBuffer(resourceName), offset, range);
     }
 
     void CommandContext::SetUniformBuffer(string_view bindingName,
@@ -501,7 +501,7 @@ namespace sp::vulkan {
         vk::DeviceSize offset,
         vk::DeviceSize range) {
         Assert(resources, "Render Graph resources not set on CommandContext");
-        SetUniformBuffer(bindingName, resources->GetBuffer(resourceID));
+        SetUniformBuffer(bindingName, resources->GetBuffer(resourceID), offset, range);
     }
 
     void CommandContext::SetStorageBuffer(uint32 set,
@@ -560,7 +560,7 @@ namespace sp::vulkan {
         vk::DeviceSize offset,
         vk::DeviceSize range) {
         Assert(resources, "Render Graph resources not set on CommandContext");
-        SetStorageBuffer(bindingName, resources->GetBuffer(resourceName));
+        SetStorageBuffer(bindingName, resources->GetBuffer(resourceName), offset, range);
     }
 
     void CommandContext::SetStorageBuffer(string_view bindingName,
@@ -568,7 +568,7 @@ namespace sp::vulkan {
         vk::DeviceSize offset,
         vk::DeviceSize range) {
         Assert(resources, "Render Graph resources not set on CommandContext");
-        SetStorageBuffer(bindingName, resources->GetBuffer(resourceID));
+        SetStorageBuffer(bindingName, resources->GetBuffer(resourceID), offset, range);
     }
 
     BufferPtr CommandContext::AllocUniformBuffer(uint32 set, uint32 binding, vk::DeviceSize size) {

--- a/src/graphics/graphics/vulkan/core/CommandContext.cc
+++ b/src/graphics/graphics/vulkan/core/CommandContext.cc
@@ -174,10 +174,10 @@ namespace sp::vulkan {
     void CommandContext::DrawScreenCover(const ImageViewPtr &view) {
         SetShaders("screen_cover.vert", "screen_cover.frag");
         if (view) {
-            SetImageView(0, 0, view);
             if (view->ViewType() == vk::ImageViewType::e2DArray) {
                 SetSingleShader(ShaderStage::Fragment, "screen_cover_array.frag");
             }
+            SetImageView("tex", view);
         }
         Draw(3); // vertices are defined as constants in the vertex shader
     }
@@ -275,33 +275,34 @@ namespace sp::vulkan {
         spec.set.reset();
         SetDirty(DirtyFlags::Pipeline);
 
-        auto shader = device.GetShader(slot);
-        if (shader) {
-            for (auto &set : shader->descriptorSets) {
-                for (auto &binding : set.bindings) {
-                    if (!binding.accessed) continue;
-                    // if (binding.type != vk::DescriptorType::eUniformBuffer) continue;
+        // TODO: Move autobinding to FlushDescriptorSets
+        // auto shader = device.GetShader(slot);
+        // if (shader) {
+        //     for (auto &set : shader->descriptorSets) {
+        //         for (auto &binding : set.bindings) {
+        //             if (!binding.accessed) continue;
+        //             // if (binding.type != vk::DescriptorType::eUniformBuffer) continue;
 
-                    if (starts_with(binding.name, "G_")) {
-                        Assertf(resources, "Render Graph resources not set on CommandContext");
-                        auto id = resources->GetID(binding.name.substr(2), false);
-                        if (binding.type == vk::DescriptorType::eUniformBuffer) {
-                            if (id == render_graph::InvalidResource) {
-                                Warnf("Shader(%s): tried to autobind missing resource: %s",
-                                    shader->name,
-                                    binding.name.substr(2));
-                            }
-                            SetUniformBuffer(set.setId, binding.bindingId, resources->GetBuffer(id));
-                        } else {
-                            Warnf("Shader(%s): autobinding type on %s is unimplemented: %s",
-                                shader->name,
-                                binding.name,
-                                binding.type);
-                        }
-                    }
-                }
-            }
-        }
+        //             if (starts_with(binding.name, "G_")) {
+        //                 Assert(resources, "Render Graph resources not set on CommandContext");
+        //                 auto id = resources->GetID(binding.name.substr(2), false);
+        //                 if (binding.type == vk::DescriptorType::eUniformBuffer) {
+        //                     if (id == render_graph::InvalidResource) {
+        //                         Warnf("Shader(%s): tried to autobind missing resource: %s",
+        //                             shader->name,
+        //                             binding.name.substr(2));
+        //                     }
+        //                     SetUniformBuffer(set.setId, binding.bindingId, resources->GetBuffer(id));
+        //                 } else {
+        //                     Warnf("Shader(%s): autobinding type on %s is unimplemented: %s",
+        //                         shader->name,
+        //                         binding.name,
+        //                         binding.type);
+        //                 }
+        //             }
+        //         }
+        //     }
+        // }
     }
 
     void CommandContext::SetSingleShader(ShaderStage stage, string_view name) {
@@ -351,6 +352,27 @@ namespace sp::vulkan {
         SetDescriptorDirty(set);
     }
 
+    void CommandContext::SetSampler(string_view bindingName, const vk::Sampler &sampler) {
+        std::shared_ptr<Shader> lastShader;
+        for (auto stage : magic_enum::enum_values<ShaderStage>()) {
+            auto &slot = pipelineInput.state.shaders[stage];
+            auto shader = device.GetShader(slot);
+            if (!shader) continue;
+            lastShader = shader;
+            for (auto &set : shader->descriptorSets) {
+                for (auto &binding : set.bindings) {
+                    if (binding.type != vk::DescriptorType::eCombinedImageSampler) continue;
+                    if (binding.name == bindingName) {
+                        SetSampler(set.setId, binding.bindingId, sampler);
+                        return;
+                    }
+                }
+            }
+        }
+        Assert(lastShader, "SetSampler called with no shader bound");
+        Errorf("SetSampler binding %s not found on any bound shader: (last: %s)", bindingName, lastShader->name);
+    }
+
     void CommandContext::SetImageView(uint32 set, uint32 binding, const ImageViewPtr &view) {
         SetImageView(set, binding, view.get());
     }
@@ -368,6 +390,43 @@ namespace sp::vulkan {
 
         auto defaultSampler = view->DefaultSampler();
         if (defaultSampler) SetSampler(set, binding, defaultSampler);
+    }
+
+    void CommandContext::SetImageView(string_view bindingName, const ImageViewPtr &view) {
+        SetImageView(bindingName, view.get());
+    }
+
+    void CommandContext::SetImageView(string_view bindingName, const ImageView *view) {
+        std::shared_ptr<Shader> lastShader;
+        for (auto stage : magic_enum::enum_values<ShaderStage>()) {
+            auto &slot = pipelineInput.state.shaders[stage];
+            auto shader = device.GetShader(slot);
+            if (!shader) continue;
+            lastShader = shader;
+            for (auto &set : shader->descriptorSets) {
+                for (auto &binding : set.bindings) {
+                    if (binding.type != vk::DescriptorType::eStorageImage &&
+                        binding.type != vk::DescriptorType::eCombinedImageSampler)
+                        continue;
+                    if (binding.name == bindingName) {
+                        SetImageView(set.setId, binding.bindingId, view);
+                        return;
+                    }
+                }
+            }
+        }
+        Assert(lastShader, "SetImageView called with no shader bound");
+        Errorf("SetImageView binding %s not found on any bound shader: (last: %s)", bindingName, lastShader->name);
+    }
+
+    void CommandContext::SetImageView(string_view bindingName, render_graph::ResourceID resourceID) {
+        Assert(resources, "Render Graph resources not set on CommandContext");
+        SetImageView(bindingName, resources->GetImageView(resourceID));
+    }
+
+    void CommandContext::SetImageView(string_view bindingName, string_view resourceName) {
+        Assert(resources, "Render Graph resources not set on CommandContext");
+        SetImageView(bindingName, resources->GetImageView(resourceName));
     }
 
     static void checkBufferOffsets(const BufferPtr &buffer, vk::DeviceSize offset, vk::DeviceSize range) {
@@ -405,6 +464,46 @@ namespace sp::vulkan {
         SetDescriptorDirty(set);
     }
 
+    void CommandContext::SetUniformBuffer(string_view bindingName,
+        const BufferPtr &buffer,
+        vk::DeviceSize offset,
+        vk::DeviceSize range) {
+        std::shared_ptr<Shader> lastShader;
+        for (auto stage : magic_enum::enum_values<ShaderStage>()) {
+            auto &slot = pipelineInput.state.shaders[stage];
+            auto shader = device.GetShader(slot);
+            if (!shader) continue;
+            lastShader = shader;
+            for (auto &set : shader->descriptorSets) {
+                for (auto &binding : set.bindings) {
+                    if (binding.type != vk::DescriptorType::eUniformBuffer) continue;
+                    if (binding.name == bindingName) {
+                        SetUniformBuffer(set.setId, binding.bindingId, buffer, offset, range);
+                        return;
+                    }
+                }
+            }
+        }
+        Assert(lastShader, "SetUniformBuffer called with no shader bound");
+        Errorf("SetUniformBuffer binding %s not found on any bound shader: (last: %s)", bindingName, lastShader->name);
+    }
+
+    void CommandContext::SetUniformBuffer(string_view bindingName,
+        string_view resourceName,
+        vk::DeviceSize offset,
+        vk::DeviceSize range) {
+        Assert(resources, "Render Graph resources not set on CommandContext");
+        SetUniformBuffer(bindingName, resources->GetBuffer(resourceName));
+    }
+
+    void CommandContext::SetUniformBuffer(string_view bindingName,
+        render_graph::ResourceID resourceID,
+        vk::DeviceSize offset,
+        vk::DeviceSize range) {
+        Assert(resources, "Render Graph resources not set on CommandContext");
+        SetUniformBuffer(bindingName, resources->GetBuffer(resourceID));
+    }
+
     void CommandContext::SetStorageBuffer(uint32 set,
         uint32 binding,
         const BufferPtr &buffer,
@@ -432,6 +531,46 @@ namespace sp::vulkan {
         SetDescriptorDirty(set);
     }
 
+    void CommandContext::SetStorageBuffer(string_view bindingName,
+        const BufferPtr &buffer,
+        vk::DeviceSize offset,
+        vk::DeviceSize range) {
+        std::shared_ptr<Shader> lastShader;
+        for (auto stage : magic_enum::enum_values<ShaderStage>()) {
+            auto &slot = pipelineInput.state.shaders[stage];
+            auto shader = device.GetShader(slot);
+            if (!shader) continue;
+            lastShader = shader;
+            for (auto &set : shader->descriptorSets) {
+                for (auto &binding : set.bindings) {
+                    if (binding.type != vk::DescriptorType::eStorageBuffer) continue;
+                    if (binding.name == bindingName) {
+                        SetStorageBuffer(set.setId, binding.bindingId, buffer, offset, range);
+                        return;
+                    }
+                }
+            }
+        }
+        Assert(lastShader, "SetStorageBuffer called with no shader bound");
+        Errorf("SetStorageBuffer binding %s not found on any bound shader: (last: %s)", bindingName, lastShader->name);
+    }
+
+    void CommandContext::SetStorageBuffer(string_view bindingName,
+        string_view resourceName,
+        vk::DeviceSize offset,
+        vk::DeviceSize range) {
+        Assert(resources, "Render Graph resources not set on CommandContext");
+        SetStorageBuffer(bindingName, resources->GetBuffer(resourceName));
+    }
+
+    void CommandContext::SetStorageBuffer(string_view bindingName,
+        render_graph::ResourceID resourceID,
+        vk::DeviceSize offset,
+        vk::DeviceSize range) {
+        Assert(resources, "Render Graph resources not set on CommandContext");
+        SetStorageBuffer(bindingName, resources->GetBuffer(resourceID));
+    }
+
     BufferPtr CommandContext::AllocUniformBuffer(uint32 set, uint32 binding, vk::DeviceSize size) {
         BufferDesc desc;
         desc.layout = size;
@@ -439,6 +578,16 @@ namespace sp::vulkan {
         desc.residency = Residency::CPU_TO_GPU;
         auto buffer = device.GetBuffer(desc);
         SetUniformBuffer(set, binding, buffer);
+        return buffer;
+    }
+
+    BufferPtr CommandContext::AllocUniformBuffer(string_view bindingName, vk::DeviceSize size) {
+        BufferDesc desc;
+        desc.layout = size;
+        desc.usage = vk::BufferUsageFlagBits::eUniformBuffer;
+        desc.residency = Residency::CPU_TO_GPU;
+        auto buffer = device.GetBuffer(desc);
+        SetUniformBuffer(bindingName, buffer);
         return buffer;
     }
 

--- a/src/graphics/graphics/vulkan/core/CommandContext.hh
+++ b/src/graphics/graphics/vulkan/core/CommandContext.hh
@@ -39,7 +39,8 @@ namespace sp::vulkan {
 
     namespace render_graph {
         class Resources;
-    }
+        typedef uint32 ResourceID;
+    } // namespace render_graph
 
     struct ImageBarrierInfo {
         uint32 baseMipLevel = 0;
@@ -372,12 +373,29 @@ namespace sp::vulkan {
 
         void SetImageView(uint32 set, uint32 binding, const ImageViewPtr &view);
         void SetImageView(uint32 set, uint32 binding, const ImageView *view);
+        void SetImageView(string_view bindingName, const ImageViewPtr &view);
+        void SetImageView(string_view bindingName, const ImageView *view);
+        void SetImageView(string_view bindingName, render_graph::ResourceID resourceID);
+        void SetImageView(string_view bindingName, string_view resourceName);
         void SetSampler(uint32 set, uint32 binding, const vk::Sampler &sampler);
+        void SetSampler(string_view bindingName, const vk::Sampler &sampler);
 
         // Binds a buffer as to a uniform descriptor. Defaults to the whole buffer.
         void SetUniformBuffer(uint32 set,
             uint32 binding,
             const BufferPtr &buffer,
+            vk::DeviceSize offset = 0,
+            vk::DeviceSize range = 0);
+        void SetUniformBuffer(string_view bindingName,
+            const BufferPtr &buffer,
+            vk::DeviceSize offset = 0,
+            vk::DeviceSize range = 0);
+        void SetUniformBuffer(string_view bindingName,
+            render_graph::ResourceID resourceID,
+            vk::DeviceSize offset = 0,
+            vk::DeviceSize range = 0);
+        void SetUniformBuffer(string_view bindingName,
+            string_view resourceName,
             vk::DeviceSize offset = 0,
             vk::DeviceSize range = 0);
 
@@ -387,9 +405,22 @@ namespace sp::vulkan {
             const BufferPtr &buffer,
             vk::DeviceSize offset = 0,
             vk::DeviceSize range = 0);
+        void SetStorageBuffer(string_view bindingName,
+            const BufferPtr &buffer,
+            vk::DeviceSize offset = 0,
+            vk::DeviceSize range = 0);
+        void SetStorageBuffer(string_view bindingName,
+            render_graph::ResourceID resourceID,
+            vk::DeviceSize offset = 0,
+            vk::DeviceSize range = 0);
+        void SetStorageBuffer(string_view bindingName,
+            string_view resourceName,
+            vk::DeviceSize offset = 0,
+            vk::DeviceSize range = 0);
 
         // Buffer is stored in a pool for this frame, and reused in later frames.
         BufferPtr AllocUniformBuffer(uint32 set, uint32 binding, vk::DeviceSize size);
+        BufferPtr AllocUniformBuffer(string_view bindingName, vk::DeviceSize size);
 
         // Returns a CPU mapped pointer to the GPU buffer, valid at least until the CommandContext is submitted
         template<typename T>
@@ -401,6 +432,12 @@ namespace sp::vulkan {
         template<typename T>
         void UploadUniformData(uint32 set, uint32 binding, const T *data, uint32 count = 1) {
             auto buffer = AllocUniformBuffer(set, binding, sizeof(T) * count);
+            buffer->CopyFrom(data, count);
+        }
+
+        template<typename T>
+        void UploadUniformData(string_view bindingName, const T *data, uint32 count = 1) {
+            auto buffer = AllocUniformBuffer(bindingName, sizeof(T) * count);
             buffer->CopyFrom(data, count);
         }
 

--- a/src/graphics/graphics/vulkan/core/DeviceContext.cc
+++ b/src/graphics/graphics/vulkan/core/DeviceContext.cc
@@ -1140,7 +1140,7 @@ namespace sp::vulkan {
 
                     image->SetLayout(lastLayout, vk::ImageLayout::eGeneral);
                     factorCmd->SetComputeShader("texture_factor.comp");
-                    factorCmd->SetImageView(0, 0, factorView);
+                    factorCmd->SetImageView("texture", factorView);
 
                     struct {
                         glm::vec4 factor;

--- a/src/graphics/graphics/vulkan/core/Shader.cc
+++ b/src/graphics/graphics/vulkan/core/Shader.cc
@@ -5,8 +5,6 @@
  * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-#pragma once
-
 #include "Shader.hh"
 
 #include "common/InlineVector.hh"

--- a/src/graphics/graphics/vulkan/gui/GuiRenderer.cc
+++ b/src/graphics/graphics/vulkan/gui/GuiRenderer.cc
@@ -169,7 +169,7 @@ namespace sp::vulkan {
                     pcmd.UserCallback(cmdList, &pcmd);
                 } else {
                     auto texture = ImageView::FromHandle((uintptr_t)pcmd.TextureId);
-                    cmd.SetImageView(0, 0, texture);
+                    cmd.SetImageView("tex", texture);
 
                     auto clipRect = pcmd.ClipRect;
                     clipRect.x -= drawData->DisplayPos.x;

--- a/src/graphics/graphics/vulkan/render_passes/Bloom.cc
+++ b/src/graphics/graphics/vulkan/render_passes/Bloom.cc
@@ -35,9 +35,9 @@ namespace sp::vulkan::renderer {
             })
             .Execute([sourceID, blur1, blur2](rg::Resources &resources, CommandContext &cmd) {
                 cmd.SetShaders("screen_cover.vert", "bloom_combine.frag");
-                cmd.SetImageView(0, 0, resources.GetImageView(sourceID));
-                cmd.SetImageView(0, 1, resources.GetImageView(blur1));
-                cmd.SetImageView(0, 2, resources.GetImageView(blur2));
+                cmd.SetImageView("luminanceTex", sourceID);
+                cmd.SetImageView("blurTex1", blur1);
+                cmd.SetImageView("blurTex2", blur2);
                 cmd.Draw(3);
             });
     }

--- a/src/graphics/graphics/vulkan/render_passes/Blur.cc
+++ b/src/graphics/graphics/vulkan/render_passes/Blur.cc
@@ -46,7 +46,7 @@ namespace sp::vulkan::renderer {
                     cmd.SetShaders("screen_cover.vert", "gaussian_blur.frag");
                 }
 
-                cmd.SetImageView(0, 0, source);
+                cmd.SetImageView("sourceTex", source);
                 cmd.PushConstants(constants);
                 cmd.Draw(3);
             });

--- a/src/graphics/graphics/vulkan/render_passes/Emissive.cc
+++ b/src/graphics/graphics/vulkan/render_passes/Emissive.cc
@@ -108,13 +108,13 @@ namespace sp::vulkan::renderer {
                 cmd.SetBlending(true);
                 cmd.SetBlendFunc(vk::BlendFactor::eSrcAlpha, vk::BlendFactor::eOne);
                 cmd.SetPrimitiveTopology(vk::PrimitiveTopology::eTriangleStrip);
-                cmd.SetUniformBuffer(0, 0, resources.GetBuffer("ViewState"));
-                cmd.SetStorageBuffer(0, 1, resources.GetBuffer("ExposureState"));
 
                 {
                     RenderPhase phase("LaserLines");
                     phase.StartTimer(cmd);
                     cmd.SetShaders("laser_billboard.vert", "laser_billboard.frag");
+                    cmd.SetUniformBuffer("ViewStates", "ViewState");
+                    cmd.SetStorageBuffer("ExposureState", "ExposureState");
 
                     struct {
                         glm::vec3 radiance;
@@ -145,6 +145,8 @@ namespace sp::vulkan::renderer {
                     cmd.SetShaders("laser_contact.vert", "laser_contact.frag");
                     cmd.SetImageView("gBuffer0", "GBuffer0");
                     cmd.SetImageView("gBuffer1", "GBuffer1");
+                    cmd.SetUniformBuffer("ViewStates", "ViewState");
+                    cmd.SetStorageBuffer("ExposureState", "ExposureState");
 
                     struct {
                         glm::vec3 radiance;

--- a/src/graphics/graphics/vulkan/render_passes/Emissive.cc
+++ b/src/graphics/graphics/vulkan/render_passes/Emissive.cc
@@ -143,8 +143,8 @@ namespace sp::vulkan::renderer {
                     RenderPhase phase("LaserContactPoints");
                     phase.StartTimer(cmd);
                     cmd.SetShaders("laser_contact.vert", "laser_contact.frag");
-                    cmd.SetImageView(0, 2, resources.GetImageView("GBuffer0"));
-                    cmd.SetImageView(0, 3, resources.GetImageView("GBuffer1"));
+                    cmd.SetImageView("gBuffer0", "GBuffer0");
+                    cmd.SetImageView("gBuffer1", "GBuffer1");
 
                     struct {
                         glm::vec3 radiance;
@@ -165,10 +165,10 @@ namespace sp::vulkan::renderer {
                     RenderPhase phase("Screens");
                     phase.StartTimer(cmd);
                     cmd.SetShaders("textured_quad.vert", "single_texture.frag");
-                    cmd.SetUniformBuffer(0, 1, resources.GetBuffer("ViewState"));
+                    cmd.SetUniformBuffer("ViewStates", "ViewState");
 
                     for (auto &screen : screens) {
-                        cmd.SetImageView(0, 0, resources.GetImageView(screen.id));
+                        cmd.SetImageView("tex", screen.id);
                         cmd.PushConstants(screen.gpuData);
                         cmd.Draw(4);
                     }

--- a/src/graphics/graphics/vulkan/render_passes/Exposure.cc
+++ b/src/graphics/graphics/vulkan/render_passes/Exposure.cc
@@ -106,9 +106,9 @@ namespace sp::vulkan::renderer {
                 auto luminance = resources.GetImageLayerView(source, 0);
 
                 cmd.SetComputeShader("lumi_histogram.comp");
-                cmd.SetImageView(0, 0, luminance);
-                cmd.SetImageView(0, 1, resources.GetImageView("LuminanceHistogram"));
-                cmd.SetStorageBuffer(0, 2, resources.GetBuffer("ExposureState"));
+                cmd.SetImageView("lumiTex", luminance);
+                cmd.SetImageView("finalHistogram", "LuminanceHistogram");
+                cmd.SetStorageBuffer("ExposureState", "ExposureState");
 
                 auto width = luminance->Extent().width / downsample;
                 auto height = luminance->Extent().height / downsample;
@@ -139,9 +139,9 @@ namespace sp::vulkan::renderer {
                 constants.eyeAdaptationKeyComp = CVarEyeAdaptationKeyComp.Get();
 
                 cmd.SetComputeShader("exposure_update.comp");
-                cmd.SetImageView(0, 0, resources.GetImageView("LuminanceHistogram"));
-                cmd.SetStorageBuffer(0, 1, resources.GetBuffer("ExposureState"));
-                cmd.SetStorageBuffer(0, 2, resources.GetBuffer("NextExposureState"));
+                cmd.SetImageView("histogram", "LuminanceHistogram");
+                cmd.SetStorageBuffer("lastExposureState", "ExposureState");
+                cmd.SetStorageBuffer("nextExposureState", "NextExposureState");
                 cmd.PushConstants(constants);
                 cmd.Dispatch(1, 1, 1);
             });
@@ -158,9 +158,9 @@ namespace sp::vulkan::renderer {
                 })
                 .Execute([source](rg::Resources &resources, CommandContext &cmd) {
                     cmd.SetShaders("screen_cover.vert", "render_histogram.frag");
-                    cmd.SetImageView(0, 0, resources.GetImageView(source));
-                    cmd.SetImageView(0, 1, resources.GetImageView("LuminanceHistogram"));
-                    cmd.SetStorageBuffer(0, 2, resources.GetBuffer("ExposureState"));
+                    cmd.SetImageView("luminanceTex", source);
+                    cmd.SetImageView("histogram", "LuminanceHistogram");
+                    cmd.SetStorageBuffer("ExposureState", "ExposureState");
                     cmd.Draw(3);
                 });
     }

--- a/src/graphics/graphics/vulkan/render_passes/LightSensors.cc
+++ b/src/graphics/graphics/vulkan/render_passes/LightSensors.cc
@@ -71,10 +71,10 @@ namespace sp::vulkan::renderer {
             .Execute([data, textureSet = &scene.textures](rg::Resources &resources, CommandContext &cmd) {
                 cmd.SetComputeShader("light_sensor.comp");
 
-                cmd.SetImageView(0, 0, resources.GetImageView("ShadowMap.Linear"));
-                cmd.SetStorageBuffer(0, 1, resources.GetBuffer("LightSensorValues"));
-                cmd.SetUniformBuffer(0, 2, resources.GetBuffer("LightState"));
-                cmd.UploadUniformData(0, 3, &data->gpu);
+                cmd.SetImageView("shadowMap", "ShadowMap.Linear");
+                cmd.SetStorageBuffer("LightSensorResults", "LightSensorValues");
+                cmd.SetUniformBuffer("LightData", "LightState");
+                cmd.UploadUniformData("LightSensorData", &data->gpu);
                 cmd.SetBindlessDescriptors(1, textureSet->GetDescriptorSet());
 
                 cmd.Dispatch(1, 1, 1);

--- a/src/graphics/graphics/vulkan/render_passes/Lighting.cc
+++ b/src/graphics/graphics/vulkan/render_passes/Lighting.cc
@@ -602,7 +602,7 @@ namespace sp::vulkan::renderer {
                 cmd.SetImageView("gBuffer1", "GBuffer1");
                 cmd.SetImageView("gBuffer2", "GBuffer2");
                 cmd.SetImageView("gBufferDepth", resources.GetImageDepthView("GBufferDepthStencil"));
-                cmd.SetImageView("shadowMap", resources.GetImageView(shadowDepth));
+                cmd.SetImageView("shadowMap", shadowDepth);
                 cmd.SetImageView("voxelRadiance", "Voxels.Radiance");
                 cmd.SetImageView("voxelNormals", "Voxels.Normals");
 

--- a/src/graphics/graphics/vulkan/render_passes/Lighting.cc
+++ b/src/graphics/graphics/vulkan/render_passes/Lighting.cc
@@ -379,19 +379,19 @@ namespace sp::vulkan::renderer {
 
                 auto lastFrameID = resources.GetID("ShadowMap.Linear", false, 1);
                 if (lastFrameID != InvalidResource) {
-                    cmd.SetImageView(0, 0, resources.GetImageView(lastFrameID));
+                    cmd.SetImageView("shadowMap", lastFrameID);
                 } else {
-                    cmd.SetImageView(0, 0, scene.textures.GetSinglePixel(glm::vec4(1)));
+                    cmd.SetImageView("shadowMap", scene.textures.GetSinglePixel(glm::vec4(1)));
                 }
 
                 auto lastStateID = resources.GetID("LightState", false, 1);
                 if (lastStateID != InvalidResource) {
-                    cmd.SetUniformBuffer(0, 1, resources.GetBuffer(lastStateID));
+                    cmd.SetUniformBuffer("PreviousLightData", lastStateID);
                 } else {
-                    cmd.SetUniformBuffer(0, 1, resources.GetBuffer("LightState"));
+                    cmd.SetUniformBuffer("PreviousLightData", "LightState");
                 }
 
-                cmd.SetUniformBuffer(0, 2, resources.GetBuffer("LightState"));
+                cmd.SetUniformBuffer("LightData", "LightState");
                 cmd.SetYDirection(YDirection::Down);
 
                 struct {
@@ -426,7 +426,7 @@ namespace sp::vulkan::renderer {
 
                 for (uint32_t i = 0; i < lights.size(); i++) {
                     GPUViewState lightViews[] = {{views[i]}, {}};
-                    cmd.UploadUniformData(0, 0, lightViews, 2);
+                    cmd.UploadUniformData("ViewStates", lightViews, 2);
 
                     vk::Rect2D viewport;
                     viewport.extent = vk::Extent2D(views[i].extents.x, views[i].extents.y);
@@ -462,8 +462,8 @@ namespace sp::vulkan::renderer {
 
                 for (uint32_t i = 0; i < lights.size(); i++) {
                     GPUViewState lightViews[] = {{views[i]}, {}};
-                    cmd.UploadUniformData(0, 0, lightViews, 2);
-                    cmd.SetStorageBuffer(0, 1, visBuffer);
+                    cmd.UploadUniformData("ViewStates", lightViews, 2);
+                    cmd.SetStorageBuffer("OpticVisibility", visBuffer);
 
                     vk::Rect2D viewport;
                     viewport.extent = vk::Extent2D(views[i].extents.x, views[i].extents.y);
@@ -598,18 +598,18 @@ namespace sp::vulkan::renderer {
                 cmd.SetStencilCompareMask(vk::StencilFaceFlagBits::eFrontAndBack, 1);
                 cmd.SetStencilReference(vk::StencilFaceFlagBits::eFrontAndBack, 1);
 
-                cmd.SetImageView(0, 0, resources.GetImageView("GBuffer0"));
-                cmd.SetImageView(0, 1, resources.GetImageView("GBuffer1"));
-                cmd.SetImageView(0, 2, resources.GetImageView("GBuffer2"));
-                cmd.SetImageView(0, 3, resources.GetImageDepthView("GBufferDepthStencil"));
-                cmd.SetImageView(0, 4, resources.GetImageView(shadowDepth));
-                cmd.SetImageView(0, 5, resources.GetImageView("Voxels.Radiance"));
-                cmd.SetImageView(0, 6, resources.GetImageView("Voxels.Normals"));
+                cmd.SetImageView("gBuffer0", "GBuffer0");
+                cmd.SetImageView("gBuffer1", "GBuffer1");
+                cmd.SetImageView("gBuffer2", "GBuffer2");
+                cmd.SetImageView("gBufferDepth", resources.GetImageDepthView("GBufferDepthStencil"));
+                cmd.SetImageView("shadowMap", resources.GetImageView(shadowDepth));
+                cmd.SetImageView("voxelRadiance", "Voxels.Radiance");
+                cmd.SetImageView("voxelNormals", "Voxels.Normals");
 
-                cmd.SetUniformBuffer(0, 8, resources.GetBuffer("VoxelState"));
-                cmd.SetStorageBuffer(0, 9, resources.GetBuffer("ExposureState"));
-                cmd.SetUniformBuffer(0, 10, resources.GetBuffer("ViewState"));
-                cmd.SetUniformBuffer(0, 11, resources.GetBuffer("LightState"));
+                cmd.SetUniformBuffer("VoxelStateUniform", "VoxelState");
+                cmd.SetStorageBuffer("ExposureState", "ExposureState");
+                cmd.SetUniformBuffer("ViewStates", "ViewState");
+                cmd.SetUniformBuffer("LightData", "LightState");
 
                 cmd.SetBindlessDescriptors(1, scene.textures.GetDescriptorSet());
 

--- a/src/graphics/graphics/vulkan/render_passes/Outline.cc
+++ b/src/graphics/graphics/vulkan/render_passes/Outline.cc
@@ -27,7 +27,7 @@ namespace sp::vulkan::renderer {
             .Execute([drawIDs, scene = &scene](Resources &resources, CommandContext &cmd) {
                 cmd.SetShaders("scene.vert", "solid_color.frag");
                 cmd.PushConstants(glm::vec4(1, 1, 0.5, 0.2));
-                cmd.SetUniformBuffer(0, 10, resources.GetBuffer("ViewState"));
+                cmd.SetUniformBuffer("ViewStates", "ViewState");
                 cmd.SetDepthTest(false, false);
                 cmd.SetDepthCompareOp(vk::CompareOp::eLessOrEqual);
 
@@ -58,7 +58,7 @@ namespace sp::vulkan::renderer {
             .Execute([drawIDs, scene = &scene](Resources &resources, CommandContext &cmd) {
                 cmd.SetShaders("scene.vert", "solid_color.frag");
                 cmd.PushConstants(glm::vec4(glm::vec3(4, 10, 0.5), 1));
-                cmd.SetUniformBuffer(0, 10, resources.GetBuffer("ViewState"));
+                cmd.SetUniformBuffer("ViewStates", "ViewState");
                 cmd.SetDepthTest(false, false);
                 cmd.SetDepthCompareOp(vk::CompareOp::eLessOrEqual);
 

--- a/src/graphics/graphics/vulkan/render_passes/SMAA.cc
+++ b/src/graphics/graphics/vulkan/render_passes/SMAA.cc
@@ -34,7 +34,7 @@ namespace sp::vulkan::renderer {
             })
             .Execute([](Resources &res, CommandContext &cmd) {
                 cmd.SetShaders("screen_cover.vert", "gamma_correct.frag");
-                cmd.SetImageView(0, 0, res.GetImageView("LinearLuminance"));
+                cmd.SetImageView("tex", "LinearLuminance");
                 cmd.Draw(3);
             });
 
@@ -53,7 +53,7 @@ namespace sp::vulkan::renderer {
             })
             .Execute([](Resources &res, CommandContext &cmd) {
                 cmd.SetShaders("screen_cover.vert", "smaa/edge_detection.frag");
-                cmd.SetImageView(0, 0, res.GetImageView("luminance"));
+                cmd.SetImageView("gammaCorrLumaTex", "luminance");
                 cmd.SetDepthTest(false, false);
                 cmd.SetStencilTest(true);
                 cmd.SetStencilCompareOp(vk::CompareOp::eAlways);
@@ -62,7 +62,7 @@ namespace sp::vulkan::renderer {
                 cmd.SetStencilFailOp(vk::StencilOp::eKeep);
                 cmd.SetStencilDepthFailOp(vk::StencilOp::eKeep);
                 cmd.SetStencilPassOp(vk::StencilOp::eReplace);
-                cmd.SetUniformBuffer(0, 10, res.GetBuffer("ViewState"));
+                cmd.SetUniformBuffer("ViewStates", "ViewState");
                 cmd.Draw(3);
             });
 
@@ -78,9 +78,9 @@ namespace sp::vulkan::renderer {
             })
             .Execute([this](Resources &res, CommandContext &cmd) {
                 cmd.SetShaders("screen_cover.vert", "smaa/blending_weights.frag");
-                cmd.SetImageView(0, 0, res.GetImageView("edges"));
-                cmd.SetImageView(0, 1, areaTex->Get());
-                cmd.SetImageView(0, 2, searchTex->Get());
+                cmd.SetImageView("edgesTex", "edges");
+                cmd.SetImageView("areaTex", areaTex->Get());
+                cmd.SetImageView("searchTex", searchTex->Get());
                 cmd.SetDepthTest(false, false);
                 cmd.SetStencilTest(true);
                 cmd.SetStencilCompareOp(vk::CompareOp::eEqual);
@@ -90,7 +90,7 @@ namespace sp::vulkan::renderer {
                 cmd.SetStencilDepthFailOp(vk::StencilOp::eKeep);
                 cmd.SetStencilPassOp(vk::StencilOp::eReplace);
                 cmd.SetStencilWriteMask(vk::StencilFaceFlagBits::eFront, 0);
-                cmd.SetUniformBuffer(0, 10, res.GetBuffer("ViewState"));
+                cmd.SetUniformBuffer("ViewStates", "ViewState");
                 cmd.Draw(3);
             });
 
@@ -105,9 +105,9 @@ namespace sp::vulkan::renderer {
             })
             .Execute([sourceID](Resources &res, CommandContext &cmd) {
                 cmd.SetShaders("screen_cover.vert", "smaa/blending.frag");
-                cmd.SetImageView(0, 0, res.GetImageView(sourceID));
-                cmd.SetImageView(0, 1, res.GetImageView("weights"));
-                cmd.SetUniformBuffer(0, 10, res.GetBuffer("ViewState"));
+                cmd.SetImageView("colorTex", sourceID);
+                cmd.SetImageView("weightTex", "weights");
+                cmd.SetUniformBuffer("ViewStates", "ViewState");
                 cmd.Draw(3);
             });
     }

--- a/src/graphics/graphics/vulkan/render_passes/Tonemap.cc
+++ b/src/graphics/graphics/vulkan/render_passes/Tonemap.cc
@@ -22,7 +22,7 @@ namespace sp::vulkan::renderer {
             })
             .Execute([](rg::Resources &resources, CommandContext &cmd) {
                 cmd.SetShaders("screen_cover.vert", "tonemap.frag");
-                cmd.SetImageView(0, 0, resources.GetImageView(resources.LastOutputID()));
+                cmd.SetImageView("luminanceTex", resources.LastOutputID());
                 cmd.Draw(3);
             });
     }

--- a/src/graphics/graphics/vulkan/render_passes/Transparency.cc
+++ b/src/graphics/graphics/vulkan/render_passes/Transparency.cc
@@ -56,14 +56,14 @@ namespace sp::vulkan::renderer {
                     vk::BlendFactor::eZero,
                     vk::BlendFactor::eOne);
 
-                cmd.SetImageView(0, 0, resources.GetImageView("ShadowMap.Linear"));
-                cmd.SetImageView(0, 1, resources.GetImageView("Voxels.Radiance"));
-                cmd.SetImageView(0, 2, resources.GetImageView("Voxels.Normals"));
+                cmd.SetImageView("shadowMap", "ShadowMap.Linear");
+                cmd.SetImageView("voxelRadiance", "Voxels.Radiance");
+                cmd.SetImageView("voxelNormals", "Voxels.Normals");
 
-                cmd.SetUniformBuffer(0, 8, resources.GetBuffer("VoxelState"));
-                cmd.SetStorageBuffer(0, 9, resources.GetBuffer("ExposureState"));
-                cmd.SetUniformBuffer(0, 10, resources.GetBuffer("ViewState"));
-                cmd.SetUniformBuffer(0, 11, resources.GetBuffer("LightState"));
+                cmd.SetUniformBuffer("VoxelStateUniform", "VoxelState");
+                cmd.SetStorageBuffer("ExposureState", "ExposureState");
+                cmd.SetUniformBuffer("ViewStates", "ViewState");
+                cmd.SetUniformBuffer("LightData", "LightState");
 
                 scene.DrawSceneIndirect(cmd,
                     resources.GetBuffer("WarpedVertexBuffer"),

--- a/src/graphics/graphics/vulkan/render_passes/VisualizeBuffer.cc
+++ b/src/graphics/graphics/vulkan/render_passes/VisualizeBuffer.cc
@@ -46,7 +46,7 @@ namespace sp::vulkan::renderer {
                 }
                 cmd.SetShaderConstant(ShaderStage::Fragment, "SWIZZLE", swizzle);
 
-                cmd.SetImageView(0, 0, source);
+                cmd.SetImageView("tex", source);
                 cmd.Draw(3);
             });
         return outputID;

--- a/src/graphics/graphics/vulkan/render_passes/Voxels.cc
+++ b/src/graphics/graphics/vulkan/render_passes/Voxels.cc
@@ -351,7 +351,7 @@ namespace sp::vulkan::renderer {
                 cmd.SetShaders("voxel_fill.vert", "voxel_fill.frag");
 
                 GPUViewState lightViews[] = {{orthoAxes[0]}, {orthoAxes[1]}, {orthoAxes[2]}};
-                cmd.UploadUniformData(0, 0, lightViews, 3);
+                cmd.UploadUniformData("ViewStates", lightViews, 3);
 
                 std::array<vk::Rect2D, 3> viewports, scissors;
                 for (size_t i = 0; i < viewports.size(); i++) {
@@ -362,20 +362,20 @@ namespace sp::vulkan::renderer {
                 cmd.SetScissorArray(scissors);
                 cmd.SetCullMode(vk::CullModeFlagBits::eNone);
 
-                cmd.SetUniformBuffer(0, 1, resources.GetBuffer("VoxelState"));
-                cmd.SetUniformBuffer(0, 2, resources.GetBuffer("LightState"));
-                cmd.SetImageView(0, 3, resources.GetImageView("ShadowMap.Linear"));
-                cmd.SetImageView(0, 4, resources.GetImageMipView("FillCounters", 0));
-                cmd.SetImageView(0, 5, resources.GetImageMipView("Radiance", 0));
-                cmd.SetImageView(0, 6, resources.GetImageMipView("Normals", 0));
-                cmd.SetStorageBuffer(0, 7, resources.GetBuffer("FragmentListMetadata"));
-                cmd.SetStorageBuffer(0, 8, resources.GetBuffer("FragmentLists"));
+                cmd.SetUniformBuffer("VoxelStateUniform", resources.GetBuffer("VoxelState"));
+                cmd.SetUniformBuffer("LightData", "LightState");
+                cmd.SetImageView("shadowMap", "ShadowMap.Linear");
+                cmd.SetImageView("fillCounters", resources.GetImageMipView("FillCounters", 0));
+                cmd.SetImageView("radianceOut", resources.GetImageMipView("Radiance", 0));
+                cmd.SetImageView("normalsOut", resources.GetImageMipView("Normals", 0));
+                cmd.SetStorageBuffer("VoxelFragmentListMetadata", "FragmentListMetadata");
+                cmd.SetStorageBuffer("VoxelFragmentList", "FragmentLists");
 
                 auto lastVoxelStateID = resources.GetID("VoxelState", false, 1);
                 if (lastVoxelStateID != InvalidResource) {
-                    cmd.SetUniformBuffer(0, 9, resources.GetBuffer(lastVoxelStateID));
+                    cmd.SetUniformBuffer("PreviousVoxelStateUniform", lastVoxelStateID);
                 } else {
-                    cmd.SetUniformBuffer(0, 9, resources.GetBuffer("VoxelState"));
+                    cmd.SetUniformBuffer("PreviousVoxelStateUniform", "VoxelState");
                 }
                 for (auto &voxelLayer : VoxelLayers[voxelFillIndex]) {
                     auto lastVoxelLayerID = resources.GetID(voxelLayer.fullName, false, 1);
@@ -413,19 +413,17 @@ namespace sp::vulkan::renderer {
                     cmd.SetComputeShader("voxel_merge.comp");
                     cmd.SetShaderConstant(ShaderStage::Compute, "FRAGMENT_LIST_INDEX", i);
 
-                    cmd.SetImageView(0, 0, resources.GetImageMipView("Radiance", 0));
-                    cmd.SetImageView(0, 1, resources.GetImageMipView("Normals", 0));
+                    cmd.SetImageView("voxelRadiance", resources.GetImageMipView("Radiance", 0));
+                    cmd.SetImageView("voxelNormals", resources.GetImageMipView("Normals", 0));
 
                     auto metadata = resources.GetBuffer("FragmentListMetadata");
-                    cmd.SetStorageBuffer(0,
-                        2,
+                    cmd.SetStorageBuffer("VoxelFragmentListMetadata",
                         metadata,
                         i * sizeof(GPUVoxelFragmentList),
                         sizeof(GPUVoxelFragmentList));
 
-                    cmd.SetStorageBuffer(0,
-                        3,
-                        resources.GetBuffer("FragmentLists"),
+                    cmd.SetStorageBuffer("VoxelFragmentList",
+                        "FragmentLists",
                         fragmentListSizes[i].offset * sizeof(GPUVoxelFragment),
                         fragmentListSizes[i].capacity * sizeof(GPUVoxelFragment));
 
@@ -447,19 +445,21 @@ namespace sp::vulkan::renderer {
                 cmd.SetComputeShader("voxel_merge_serial.comp");
                 cmd.SetShaderConstant(ShaderStage::Compute, "FRAGMENT_LIST_COUNT", fragmentListCount);
 
-                cmd.SetImageView(0, 0, resources.GetImageMipView("Radiance", 0));
-                cmd.SetImageView(0, 1, resources.GetImageMipView("Normals", 0));
+                cmd.SetImageView("voxelRadiance", resources.GetImageMipView("Radiance", 0));
+                cmd.SetImageView("voxelNormals", resources.GetImageMipView("Normals", 0));
 
                 auto metadata = resources.GetBuffer("FragmentListMetadata");
-                cmd.SetStorageBuffer(0, 2, metadata, i * sizeof(GPUVoxelFragmentList), sizeof(GPUVoxelFragmentList));
+                cmd.SetStorageBuffer("VoxelFragmentListMetadata",
+                    metadata,
+                    i * sizeof(GPUVoxelFragmentList),
+                    sizeof(GPUVoxelFragmentList));
 
-                cmd.SetStorageBuffer(0,
-                    3,
-                    resources.GetBuffer("FragmentLists"),
+                cmd.SetStorageBuffer("VoxelFragmentList",
+                    "FragmentLists",
                     fragmentListSizes[i].offset * sizeof(GPUVoxelFragment),
                     fragmentListSizes[i].capacity * sizeof(GPUVoxelFragment));
 
-                cmd.SetImageView(0, 4, resources.GetImageMipView("FillCounters", 0));
+                cmd.SetImageView("fillCounters", resources.GetImageMipView("FillCounters", 0));
 
                 cmd.Dispatch(1, 1, 1);
             });
@@ -475,13 +475,13 @@ namespace sp::vulkan::renderer {
                 .Execute([this, i](rg::Resources &resources, CommandContext &cmd) {
                     cmd.SetComputeShader("voxel_mipmap.comp");
 
-                    cmd.SetImageView(0, 0, resources.GetImageMipView("Radiance", i - 1));
-                    cmd.SetSampler(0, 0, cmd.Device().GetSampler(SamplerType::TrilinearClampEdge));
-                    cmd.SetImageView(0, 1, resources.GetImageMipView("Radiance", i));
+                    cmd.SetImageView("voxelRadianceIn", resources.GetImageMipView("Radiance", i - 1));
+                    cmd.SetSampler("voxelRadianceIn", cmd.Device().GetSampler(SamplerType::TrilinearClampEdge));
+                    cmd.SetImageView("voxelRadianceOut", resources.GetImageMipView("Radiance", i));
 
-                    cmd.SetImageView(0, 2, resources.GetImageMipView("Normals", i - 1));
-                    cmd.SetSampler(0, 2, cmd.Device().GetSampler(SamplerType::TrilinearClampEdge));
-                    cmd.SetImageView(0, 3, resources.GetImageMipView("Normals", i));
+                    cmd.SetImageView("voxelNormalsIn", resources.GetImageMipView("Normals", i - 1));
+                    cmd.SetSampler("voxelNormalsIn", cmd.Device().GetSampler(SamplerType::TrilinearClampEdge));
+                    cmd.SetImageView("voxelNormalsOut", resources.GetImageMipView("Normals", i));
 
                     cmd.SetShaderConstant(ShaderStage::Compute, "MIP_LEVEL", i);
 
@@ -630,14 +630,13 @@ namespace sp::vulkan::renderer {
             .Execute([this](rg::Resources &resources, CommandContext &cmd) {
                 cmd.SetComputeShader("voxel_fill_layer.comp");
 
-                cmd.SetUniformBuffer(0, 0, resources.GetBuffer("VoxelState"));
+                cmd.SetUniformBuffer("VoxelStateUniform", "VoxelState");
 
                 auto metadata = resources.GetBuffer("Voxels.FragmentListMetadata");
-                cmd.SetStorageBuffer(0, 1, metadata, 0, sizeof(GPUVoxelFragmentList));
+                cmd.SetStorageBuffer("VoxelFragmentListMetadata", metadata, 0, sizeof(GPUVoxelFragmentList));
 
-                cmd.SetStorageBuffer(0,
-                    2,
-                    resources.GetBuffer("Voxels.FragmentLists"),
+                cmd.SetStorageBuffer("VoxelFragmentList",
+                    "Voxels.FragmentLists",
                     fragmentListSizes[0].offset * sizeof(GPUVoxelFragment),
                     fragmentListSizes[0].capacity * sizeof(GPUVoxelFragment));
 
@@ -666,18 +665,16 @@ namespace sp::vulkan::renderer {
                     cmd.SetComputeShader("voxel_merge_layer.comp");
                     cmd.SetShaderConstant(ShaderStage::Compute, "FRAGMENT_LIST_INDEX", i);
 
-                    cmd.SetUniformBuffer(0, 0, resources.GetBuffer("VoxelState"));
+                    cmd.SetUniformBuffer("VoxelStateUniform", "VoxelState");
 
                     auto metadata = resources.GetBuffer("Voxels.FragmentListMetadata");
-                    cmd.SetStorageBuffer(0,
-                        1,
+                    cmd.SetStorageBuffer("VoxelFragmentListMetadata",
                         metadata,
                         i * sizeof(GPUVoxelFragmentList),
                         sizeof(GPUVoxelFragmentList));
 
-                    cmd.SetStorageBuffer(0,
-                        2,
-                        resources.GetBuffer("Voxels.FragmentLists"),
+                    cmd.SetStorageBuffer("VoxelFragmentList",
+                        "Voxels.FragmentLists",
                         fragmentListSizes[i].offset * sizeof(GPUVoxelFragment),
                         fragmentListSizes[i].capacity * sizeof(GPUVoxelFragment));
 
@@ -706,14 +703,16 @@ namespace sp::vulkan::renderer {
                 cmd.SetComputeShader("voxel_merge_layer_serial.comp");
                 cmd.SetShaderConstant(ShaderStage::Compute, "FRAGMENT_LIST_COUNT", fragmentListCount);
 
-                cmd.SetUniformBuffer(0, 0, resources.GetBuffer("VoxelState"));
+                cmd.SetUniformBuffer("VoxelStateUniform", "VoxelState");
 
                 auto metadata = resources.GetBuffer("Voxels.FragmentListMetadata");
-                cmd.SetStorageBuffer(0, 1, metadata, i * sizeof(GPUVoxelFragmentList), sizeof(GPUVoxelFragmentList));
+                cmd.SetStorageBuffer("VoxelFragmentListMetadata",
+                    metadata,
+                    i * sizeof(GPUVoxelFragmentList),
+                    sizeof(GPUVoxelFragmentList));
 
-                cmd.SetStorageBuffer(0,
-                    2,
-                    resources.GetBuffer("Voxels.FragmentLists"),
+                cmd.SetStorageBuffer("VoxelFragmentList",
+                    "Voxels.FragmentLists",
                     fragmentListSizes[i].offset * sizeof(GPUVoxelFragment),
                     fragmentListSizes[i].capacity * sizeof(GPUVoxelFragment));
 
@@ -747,13 +746,13 @@ namespace sp::vulkan::renderer {
                         layer == 1 ? CVarLightLowPass.Get() : 0.0f);
                     cmd.SetShaderConstant(ShaderStage::Compute, "LAYER_INDEX", (uint32_t)layer);
 
-                    cmd.SetUniformBuffer(0, 0, resources.GetBuffer("VoxelState"));
+                    cmd.SetUniformBuffer("VoxelStateUniform", "VoxelState");
 
                     auto lastVoxelStateID = resources.GetID("VoxelState", false, 1);
                     if (lastVoxelStateID != InvalidResource && CVarReprojectVoxelGrid.Get()) {
-                        cmd.SetUniformBuffer(0, 1, resources.GetBuffer(lastVoxelStateID));
+                        cmd.SetUniformBuffer("PreviousVoxelStateUniform", lastVoxelStateID);
                     } else {
-                        cmd.SetUniformBuffer(0, 1, resources.GetBuffer("VoxelState"));
+                        cmd.SetUniformBuffer("PreviousVoxelStateUniform", "VoxelState");
                     }
 
                     for (size_t i = 0; i < directions.size(); i++) {
@@ -843,13 +842,13 @@ namespace sp::vulkan::renderer {
                 cmd.SetStencilCompareMask(vk::StencilFaceFlagBits::eFrontAndBack, 1);
                 cmd.SetStencilReference(vk::StencilFaceFlagBits::eFrontAndBack, 1);
 
-                cmd.SetUniformBuffer(0, 0, resources.GetBuffer("ViewState"));
-                cmd.SetUniformBuffer(0, 1, resources.GetBuffer("VoxelState"));
-                cmd.SetStorageBuffer(0, 2, resources.GetBuffer("ExposureState"));
-                cmd.SetImageView(0, 3, resources.GetImageView(resources.LastOutputID()));
-                cmd.SetImageView(0, 4, resources.GetImageView("Voxels.FillCounters"));
-                cmd.SetImageView(0, 5, resources.GetImageView("Voxels.Radiance"));
-                cmd.SetImageView(0, 6, resources.GetImageView("Voxels.Normals"));
+                cmd.SetUniformBuffer("ViewStates", "ViewState");
+                cmd.SetUniformBuffer("VoxelStateUniform", "VoxelState");
+                cmd.SetStorageBuffer("ExposureState", "ExposureState");
+                cmd.SetImageView("overlayTex", resources.LastOutputID());
+                cmd.SetImageView("fillCounters", "Voxels.FillCounters");
+                cmd.SetImageView("voxelRadiance", "Voxels.Radiance");
+                cmd.SetImageView("voxelNormals", "Voxels.Normals");
 
                 for (auto &voxelLayer : VoxelLayers[debugMipLayer]) {
                     auto layerView = resources.GetImageView(voxelLayer.fullName);

--- a/src/graphics/graphics/vulkan/render_passes/Voxels.cc
+++ b/src/graphics/graphics/vulkan/render_passes/Voxels.cc
@@ -666,7 +666,7 @@ namespace sp::vulkan::renderer {
                     cmd.SetComputeShader("voxel_merge_layer.comp");
                     cmd.SetShaderConstant(ShaderStage::Compute, "FRAGMENT_LIST_INDEX", i);
 
-                    // cmd.SetUniformBuffer(0, 0, resources.GetBuffer("VoxelState"));
+                    cmd.SetUniformBuffer(0, 0, resources.GetBuffer("VoxelState"));
 
                     auto metadata = resources.GetBuffer("Voxels.FragmentListMetadata");
                     cmd.SetStorageBuffer(0,

--- a/src/graphics/graphics/vulkan/scene/GPUScene.cc
+++ b/src/graphics/graphics/vulkan/scene/GPUScene.cc
@@ -197,11 +197,11 @@ namespace sp::vulkan {
             })
             .Execute([this, viewMask, bufferIDs, instanceCount](rg::Resources &resources, CommandContext &cmd) {
                 cmd.SetComputeShader("generate_draws_for_view.comp");
-                cmd.SetStorageBuffer(0, 0, resources.GetBuffer("RenderableEntities"));
-                cmd.SetStorageBuffer(0, 1, models);
-                cmd.SetStorageBuffer(0, 2, primitiveLists);
-                cmd.SetStorageBuffer(0, 3, resources.GetBuffer(bufferIDs.drawCommandsBuffer));
-                cmd.SetStorageBuffer(0, 4, resources.GetBuffer(bufferIDs.drawParamsBuffer));
+                cmd.SetStorageBuffer("Renderables", "RenderableEntities");
+                cmd.SetStorageBuffer("MeshModels", models);
+                cmd.SetStorageBuffer("MeshPrimitives", primitiveLists);
+                cmd.SetStorageBuffer("DrawCommands", bufferIDs.drawCommandsBuffer);
+                cmd.SetStorageBuffer("DrawParamsList", bufferIDs.drawParamsBuffer);
 
                 struct {
                     uint32 renderableCount;
@@ -357,11 +357,11 @@ namespace sp::vulkan {
                 if (vertexCount == 0) return;
 
                 cmd.SetComputeShader("generate_warp_geometry_draws.comp");
-                cmd.SetStorageBuffer(0, 0, resources.GetBuffer("RenderableEntities"));
-                cmd.SetStorageBuffer(0, 1, models);
-                cmd.SetStorageBuffer(0, 2, primitiveLists);
-                cmd.SetStorageBuffer(0, 3, resources.GetBuffer("WarpedVertexDrawCmds"));
-                cmd.SetStorageBuffer(0, 4, resources.GetBuffer("WarpedVertexDrawParams"));
+                cmd.SetStorageBuffer("Renderables", "RenderableEntities");
+                cmd.SetStorageBuffer("MeshModels", models);
+                cmd.SetStorageBuffer("MeshPrimitives", primitiveLists);
+                cmd.SetStorageBuffer("DrawCommands", "WarpedVertexDrawCmds");
+                cmd.SetStorageBuffer("DrawParamsList", "WarpedVertexDrawParams");
 
                 struct {
                     uint32 renderableCount;
@@ -391,10 +391,10 @@ namespace sp::vulkan {
 
                 cmd.BeginRenderPass({});
                 cmd.SetShaders({{ShaderStage::Vertex, "warp_geometry.vert"}});
-                cmd.SetStorageBuffer(0, 0, paramBuffer);
-                cmd.SetStorageBuffer(0, 1, warpedVertexBuffer);
-                cmd.SetUniformBuffer(0, 2, resources.GetBuffer("JointPoses"));
-                cmd.SetStorageBuffer(0, 3, jointsBuffer);
+                cmd.SetStorageBuffer("DrawParamsList", paramBuffer);
+                cmd.SetStorageBuffer("VertexBufferOutput", warpedVertexBuffer);
+                cmd.SetUniformBuffer("JointPoses", "JointPoses");
+                cmd.SetStorageBuffer("JointVertexData", jointsBuffer);
 
                 cmd.SetVertexLayout(SceneVertex::Layout());
                 cmd.SetPrimitiveTopology(vk::PrimitiveTopology::ePointList);


### PR DESCRIPTION
Updates all functions that take in a `set` + `binding` index and allow binding by variable name using SPIRV-Reflect.