### PR TITLE
Add star skybox shader

### DIFF
--- a/assets/scenes/menu.json
+++ b/assets/scenes/menu.json
@@ -95,7 +95,8 @@
 				"scale": 0.1
 			},
 			"renderable": {
-				"model": "box"
+				"model": "box",
+				"visibility": "DirectCamera|DirectEye|LightingShadow"
 			},
 			"physics": {
 				"shapes": {
@@ -168,7 +169,9 @@
 				"translate": [0, 2.5, -4]
 			},
 			"renderable": {
-				"model": "box"
+				"model": "box",
+				"visibility": "Transparent",
+				"metallic_roughness_override": [0.9, 0.1]
 			},
 			"physics": {
 				"type": "Static",

--- a/shaders/vulkan/screen_cover.vert
+++ b/shaders/vulkan/screen_cover.vert
@@ -19,9 +19,10 @@ vec2 uvs[3] = vec2[](vec2(-0.5, 1), vec2(1.5, 1), vec2(0.5, -1));
 
 vec2 uvsFlipped[3] = vec2[](vec2(-0.5, 0), vec2(1.5, 0), vec2(0.5, 2));
 
-const bool flipped = false;
+layout(constant_id = 0) const bool FLIPPED = false;
+layout(constant_id = 1) const float DRAW_DEPTH = 0.0;
 
 void main() {
-    outTexCoord = flipped ? uvsFlipped[gl_VertexIndex] : uvs[gl_VertexIndex];
-    gl_Position = vec4(positions[gl_VertexIndex], 0.0, 1.0);
+    outTexCoord = FLIPPED ? uvsFlipped[gl_VertexIndex] : uvs[gl_VertexIndex];
+    gl_Position = vec4(positions[gl_VertexIndex], DRAW_DEPTH, 1.0);
 }

--- a/shaders/vulkan/skybox.frag
+++ b/shaders/vulkan/skybox.frag
@@ -30,15 +30,14 @@ layout(push_constant) uniform PushConstants {
     float starSize;
 };
 
-const vec3[3] colorTints = vec3[](vec3(255, 182, 119) / 255,
-    vec3(255, 252, 246) / 255,
-    vec3(188, 210, 255) / 255);
+const vec3[3] colorTints = vec3[](vec3(255, 182, 119) / 255, vec3(255, 252, 246) / 255, vec3(188, 210, 255) / 255);
 
 void main() {
     ViewState view = views[gl_ViewID_OVR];
 
     vec2 flippedCoord = vec2(inTexCoord.x, 1 - inTexCoord.y);
-    vec3 rayDir = mat3(rotation) * normalize(mat3(view.invViewMat) * ScreenPosToViewPos(flippedCoord, 1, view.invProjMat));
+    vec3 rayDir = normalize(
+        mat3(rotation) * mat3(view.invViewMat) * ScreenPosToViewPos(flippedCoord, 1, view.invProjMat));
     rayDir = clamp(rayDir, -1, 1);
 
     float latitude = atan(rayDir.z, rayDir.x) * (0.5 / M_PI) + 0.5;
@@ -62,7 +61,8 @@ void main() {
     vec3 starDir = vec3(cos(starAngle.x), sin(starAngle.y), sin(starAngle.x));
     starDir.xz *= cos(starAngle.y);
 
-    vec3 color = colorTints[int(rand2(rng)*3)].rgb * brightness * rand2(rng);
-    outFragColor = vec4(color * smoothstep(1 - pointSize / sqrt(length(view.extents)), 1, dot(starDir, rayDir)) * exposure, 1.0);
+    vec3 color = colorTints[int(rand2(rng) * 3)].rgb * brightness * rand2(rng);
+    float pointDist = smoothstep(1 - pointSize / sqrt(length(view.extents)), 1, dot(starDir, rayDir));
+    outFragColor = vec4(color * pointDist * exposure, 1.0);
     // outFragColor = vec4(vec3(fract(viewPos), 0) * exposure, 1.0);
 }

--- a/shaders/vulkan/skybox.frag
+++ b/shaders/vulkan/skybox.frag
@@ -1,0 +1,68 @@
+/*
+ * Stray Photons - Copyright (C) 2025 Jacob Wirth
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#version 450
+
+#extension GL_OVR_multiview2 : enable
+layout(num_views = 2) in;
+
+#include "../lib/types_common.glsl"
+#include "../lib/util.glsl"
+
+INCLUDE_LAYOUT(binding = 0)
+#include "lib/view_states_uniform.glsl"
+
+INCLUDE_LAYOUT(binding = 1)
+#include "lib/exposure_state.glsl"
+
+layout(location = 0) in vec2 inTexCoord;
+layout(location = 0) out vec4 outFragColor;
+
+layout(push_constant) uniform PushConstants {
+    mat4 rotation;
+    uint index;
+    float brightness;
+    float density;
+    float starSize;
+};
+
+const vec3[3] colorTints = vec3[](vec3(255, 182, 119) / 255,
+    vec3(255, 252, 246) / 255,
+    vec3(188, 210, 255) / 255);
+
+void main() {
+    ViewState view = views[gl_ViewID_OVR];
+
+    vec2 flippedCoord = vec2(inTexCoord.x, 1 - inTexCoord.y);
+    vec3 rayDir = mat3(rotation) * normalize(mat3(view.invViewMat) * ScreenPosToViewPos(flippedCoord, 1, view.invProjMat));
+    rayDir = clamp(rayDir, -1, 1);
+
+    float latitude = atan(rayDir.z, rayDir.x) * (0.5 / M_PI) + 0.5;
+    float longitude = asin(rayDir.y) * (1 / M_PI) + 0.5;
+
+    vec2 cellSize = vec2(1.5, 1.0) * density;
+    float distFromEquator = floor(abs(cellSize.y * 0.5 - longitude * cellSize.y)) / cellSize.y;
+    float rowScale = ceil(cos(distFromEquator * M_PI) * cellSize.x);
+    vec2 viewPos = vec2(latitude * rowScale, longitude * cellSize.y);
+
+    ivec2 cellNum = ivec2(viewPos);
+
+    vec4 rng = randState(cellNum.xyx);
+    float pointSize = rand2(rng) * starSize;
+    vec2 offsetPos = vec2(rand2(rng), rand2(rng));
+    offsetPos *= clamp(1 - (pointSize * 100), 0, 1);
+    offsetPos += clamp(pointSize * 50, 0, 0.5);
+    vec2 starAngle = (cellNum + offsetPos) / vec2(rowScale, cellSize.y);
+    starAngle.x = (starAngle.x - 0.5) * M_PI * 2;
+    starAngle.y = (starAngle.y - 0.5) * M_PI;
+    vec3 starDir = vec3(cos(starAngle.x), sin(starAngle.y), sin(starAngle.x));
+    starDir.xz *= cos(starAngle.y);
+
+    vec3 color = colorTints[int(rand2(rng)*3)].rgb * brightness * rand2(rng);
+    outFragColor = vec4(color * smoothstep(1 - pointSize / sqrt(length(view.extents)), 1, dot(starDir, rayDir)) * exposure, 1.0);
+    // outFragColor = vec4(vec3(fract(viewPos), 0) * exposure, 1.0);
+}

--- a/src/core/assets/AssetManager.hh
+++ b/src/core/assets/AssetManager.hh
@@ -50,7 +50,9 @@ namespace sp {
         void Shutdown();
 
         std::filesystem::path GetExternalPath(std::string_view path) const;
-        std::vector<std::string> ListBundledAssets(std::string_view prefix, std::string_view extension = "") const;
+        std::vector<std::string> ListBundledAssets(std::string_view prefix,
+            std::string_view extension = "",
+            size_t maxDepth = 4) const;
 
         AsyncPtr<Asset> Load(std::string_view path, AssetType type = AssetType::Bundled, bool reload = false);
         AsyncPtr<Gltf> LoadGltf(std::string_view name);

--- a/src/graphics/graphics/gui/MenuGuiManager.cc
+++ b/src/graphics/graphics/gui/MenuGuiManager.cc
@@ -340,7 +340,7 @@ namespace sp {
             {"Cornell Box Mirror", "cornell-box-3"},
             {"Test 1", "test1"},
         };
-        auto sceneAssets = Assets().ListBundledAssets("scenes/", ".json");
+        auto sceneAssets = Assets().ListBundledAssets("scenes/", ".json", 0);
         for (auto &path : sceneAssets) {
             if (starts_with(path, "scenes/") && ends_with(path, ".json")) {
                 std::string scene = path.substr(7, path.length() - 5 - 7);

--- a/src/graphics/graphics/gui/definitions/EditorControls.cc
+++ b/src/graphics/graphics/gui/definitions/EditorControls.cc
@@ -281,8 +281,11 @@ namespace sp {
                 lock.GetInstance().GetInstanceId());
         }
 
-        if (!this->target.Has<ecs::SceneInfo>(lock)) {
+        if (!this->target.Exists(lock)) {
             ImGui::Text("Missing Entity: %s", ecs::ToString(lock, this->target).c_str());
+            return;
+        } else if (!this->target.Has<ecs::SceneInfo>(lock)) {
+            ImGui::Text("Entity has no SceneInfo: %s", ecs::ToString(lock, this->target).c_str());
             return;
         }
 

--- a/src/graphics/graphics/vulkan/Renderer.cc
+++ b/src/graphics/graphics/vulkan/Renderer.cc
@@ -26,6 +26,7 @@
 #include "graphics/vulkan/render_passes/LightSensors.hh"
 #include "graphics/vulkan/render_passes/Mipmap.hh"
 #include "graphics/vulkan/render_passes/Outline.hh"
+#include "graphics/vulkan/render_passes/Skybox.hh"
 #include "graphics/vulkan/render_passes/Tonemap.hh"
 #include "graphics/vulkan/render_passes/VisualizeBuffer.hh"
 #include "graphics/vulkan/scene/Mesh.hh"
@@ -609,6 +610,7 @@ namespace sp::vulkan {
         chrono_clock::duration elapsedTime) {
         renderer::AddExposureState(graph);
         lighting.AddLightingPass(graph);
+        renderer::AddSkyboxPass(graph);
         transparency.AddPass(graph, view);
         emissive.AddPass(graph, lock, elapsedTime);
         voxels.AddDebugPass(graph);

--- a/src/graphics/graphics/vulkan/render_passes/CMakeLists.txt
+++ b/src/graphics/graphics/vulkan/render_passes/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(${PROJECT_GRAPHICS_VULKAN_CORE_LIB} PRIVATE
     Exposure.cc
     Mipmap.cc
     Screenshots.cc
+    Skybox.cc
     SMAA.cc
     Lighting.cc
     LightSensors.cc

--- a/src/graphics/graphics/vulkan/render_passes/Crosshair.cc
+++ b/src/graphics/graphics/vulkan/render_passes/Crosshair.cc
@@ -7,48 +7,51 @@
 
 #include "Crosshair.hh"
 
+#include "graphics/core/GraphicsContext.hh"
 #include "graphics/vulkan/core/CommandContext.hh"
 
 namespace sp::vulkan::renderer {
-    static void drawDots(CommandContext &cmd, vk::Offset2D offset, uint32 spread, uint32 size) {
+    static void drawDots(CommandContext &cmd, vk::Offset2D offset, glm::vec2 spread, glm::vec2 size) {
         vk::Rect2D viewport;
-        viewport.extent.width = size;
-        viewport.extent.height = size;
+        viewport.extent.width = (uint32_t)glm::round(size.x);
+        viewport.extent.height = (uint32_t)glm::round(size.y);
         viewport.offset = offset;
 
         cmd.SetViewport(viewport);
         cmd.Draw(3);
 
-        viewport.offset.x = offset.x + spread;
+        viewport.offset.x = (int32_t)glm::round((float)offset.x + spread.x);
         cmd.SetViewport(viewport);
         cmd.Draw(3);
 
-        viewport.offset.x = offset.x - spread;
+        viewport.offset.x = (int32_t)glm::round((float)offset.x - spread.x);
         cmd.SetViewport(viewport);
         cmd.Draw(3);
 
         viewport.offset.x = offset.x;
-        viewport.offset.y = offset.y + spread;
+        viewport.offset.y = (int32_t)glm::round((float)offset.y + spread.y);
         cmd.SetViewport(viewport);
         cmd.Draw(3);
 
-        viewport.offset.y = offset.y - spread;
+        viewport.offset.y = (int32_t)glm::round((float)offset.y - spread.y);
         cmd.SetViewport(viewport);
         cmd.Draw(3);
     }
 
     void AddCrosshair(RenderGraph &graph) {
+        auto windowScale = CVarWindowScale.Get();
         graph.AddPass("Crosshair")
             .Build([&](PassBuilder &builder) {
                 builder.SetColorAttachment(0, builder.LastOutputID(), {LoadOp::Load, StoreOp::Store});
             })
-            .Execute([](Resources &resources, CommandContext &cmd) {
+            .Execute([windowScale](Resources &resources, CommandContext &cmd) {
                 cmd.SetDepthTest(false, false);
                 cmd.SetShaders("screen_cover.vert", "solid_color.frag");
 
                 auto extent = cmd.GetFramebufferExtent();
                 auto center = vk::Offset2D{(int)extent.width / 2, (int)extent.height / 2};
-                auto spread = extent.width / 100;
+                glm::vec2 spread = windowScale * (float)std::min(extent.width, extent.height) / 100.0f;
+                glm::vec2 dotSize = glm::min(spread * 0.4f, windowScale * 2.0f);
 
                 cmd.PushConstants(glm::vec4(1, 1, 0.95, 0.3));
                 cmd.SetBlendFuncSeparate(vk::BlendFactor::eSrcAlpha,
@@ -56,7 +59,7 @@ namespace sp::vulkan::renderer {
                     vk::BlendFactor::eZero,
                     vk::BlendFactor::eOne);
                 cmd.SetBlending(true, vk::BlendOp::eAdd);
-                drawDots(cmd, center, spread, 2);
+                drawDots(cmd, center, spread, dotSize);
 
                 cmd.PushConstants(glm::vec4(0.6, 0.6, 0.5, 1));
                 cmd.SetBlendFuncSeparate(vk::BlendFactor::eSrcAlpha,
@@ -64,7 +67,7 @@ namespace sp::vulkan::renderer {
                     vk::BlendFactor::eZero,
                     vk::BlendFactor::eOne);
                 cmd.SetBlending(true, vk::BlendOp::eMin);
-                drawDots(cmd, center, spread, 2);
+                drawDots(cmd, center, spread, dotSize);
             });
     }
 } // namespace sp::vulkan::renderer

--- a/src/graphics/graphics/vulkan/render_passes/Skybox.cc
+++ b/src/graphics/graphics/vulkan/render_passes/Skybox.cc
@@ -1,0 +1,89 @@
+/*
+ * Stray Photons - Copyright (C) 2025 Jacob Wirth
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "Skybox.hh"
+
+#include "ecs/EcsImpl.hh"
+#include "ecs/components/View.hh"
+#include "graphics/vulkan/core/CommandContext.hh"
+#include "graphics/vulkan/core/DeviceContext.hh"
+#include "graphics/vulkan/core/PerfTimer.hh"
+#include "graphics/vulkan/render_passes/Lighting.hh"
+
+#include <glm/glm.hpp>
+
+namespace sp::vulkan::renderer {
+    static CVar<bool> CVarDrawSkybox0("r.DrawSkybox0", true, "Enable drawing the first skybox");
+    static CVar<bool> CVarDrawSkybox1("r.DrawSkybox1", true, "Enable drawing the first skybox");
+    static CVar<bool> CVarDrawSkybox2("r.DrawSkybox2", true, "Enable drawing the first skybox");
+    static CVar<float> CVarSkyboxStarBrightness("r.SkyboxStarBrightness",
+        0.08f,
+        "Brightness scaling value for star skybox");
+    static CVar<float> SkyboxStarDensity("r.SkyboxStarDensity", 100.0f, "Star tile density for skybox rendering");
+    static CVar<float> CVarSkyboxStarSize("r.SkyboxStarSize", 0.0001f, "Star size for skybox rendering");
+
+    void AddSkyboxPass(RenderGraph &graph) {
+        static const std::array<glm::vec4, 3> rotations = {
+            glm::vec4(1.0, 0.0, 0.0, M_2_PI),
+            glm::vec4(glm::normalize(glm::vec3(1.0, 0.0, 1.0)), M_PI_2),
+            glm::vec4(0.0, 0.0, 1.0, M_2_PI),
+        };
+        std::array<bool, 3> enabled = {
+            CVarDrawSkybox0.Get(),
+            CVarDrawSkybox1.Get(),
+            CVarDrawSkybox2.Get(),
+        };
+        bool first = true;
+        float brightness = CVarSkyboxStarBrightness.Get();
+        float density = SkyboxStarDensity.Get();
+        float starSize = CVarSkyboxStarSize.Get();
+        for (size_t i = 0; i < rotations.size(); i++) {
+            if (!enabled[i]) continue;
+            graph.AddPass("Skybox" + std::to_string(i))
+                .Build([&](rg::PassBuilder &builder) {
+                    builder.Read("ExposureState", Access::FragmentShaderReadStorage);
+                    builder.ReadUniform("ViewState");
+
+                    builder.SetColorAttachment(0, builder.LastOutputID(), {LoadOp::Load, StoreOp::Store});
+                    builder.SetDepthAttachment("GBufferDepthStencil", {LoadOp::Load, StoreOp::ReadOnly});
+                })
+                .Execute([i, first, brightness, density, starSize](rg::Resources &resources, CommandContext &cmd) {
+                    cmd.SetShaders("screen_cover.vert", "skybox.frag");
+
+                    cmd.SetShaderConstant(ShaderStage::Vertex, "DRAW_DEPTH", 1.0f);
+
+                    if (!first) {
+                        cmd.SetBlending(true, vk::BlendOp::eMax);
+                        cmd.SetBlendFunc(vk::BlendFactor::eSrcAlpha, vk::BlendFactor::eOne);
+                    }
+
+                    cmd.SetDepthTest(true, false);
+                    cmd.SetDepthCompareOp(vk::CompareOp::eEqual);
+
+                    cmd.SetStorageBuffer("ExposureState", "ExposureState");
+                    cmd.SetUniformBuffer("ViewStates", "ViewState");
+
+                    struct {
+                        glm::mat4 rotation;
+                        uint32_t index;
+                        float brightness, density, starSize;
+                    } constants = {
+                        glm::mat4(glm::angleAxis(rotations[i].w, glm::vec3(rotations[i]))),
+                        (uint32_t)i,
+                        brightness,
+                        density,
+                        starSize,
+                    };
+
+                    cmd.PushConstants(constants);
+
+                    cmd.Draw(3);
+                });
+            first = false;
+        }
+    }
+} // namespace sp::vulkan::renderer

--- a/src/graphics/graphics/vulkan/render_passes/Skybox.hh
+++ b/src/graphics/graphics/vulkan/render_passes/Skybox.hh
@@ -1,0 +1,19 @@
+/*
+ * Stray Photons - Copyright (C) 2025 Jacob Wirth
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include "Common.hh"
+#include "graphics/vulkan/scene/GPUScene.hh"
+
+namespace ecs {
+    struct View;
+}
+
+namespace sp::vulkan::renderer {
+    void AddSkyboxPass(RenderGraph &graph);
+} // namespace sp::vulkan::renderer


### PR DESCRIPTION
This adds a new star skybox shader that will render for any parts of the screen with nothing drawn.

Also in this PR:
- Make the menu projection wall transparent glass
- Fix the asset folder listing to only show the first directory level
- Tweak the crosshair to scale the dots with DPI scaling