### PR TITLE
Fix profiler gui not showing up

### DIFF
--- a/src/graphics/graphics/gui/GuiContext.cc
+++ b/src/graphics/graphics/gui/GuiContext.cc
@@ -72,7 +72,7 @@ namespace sp {
         if (it != components.end()) components.erase(it);
     }
 
-    std::weak_ptr<ecs::GuiRenderable> CreateGuiWindow(const ecs::Gui &gui, const ecs::Scripts *scripts) {
+    GuiContext::Ref CreateGuiWindow(const ecs::Gui &gui, const ecs::Scripts *scripts) {
         if (gui.windowName == "lobby") {
             static const auto lobby = make_shared<LobbyGui>(gui.windowName);
             return lobby;

--- a/src/graphics/graphics/gui/GuiContext.hh
+++ b/src/graphics/graphics/gui/GuiContext.hh
@@ -56,7 +56,7 @@ namespace sp {
         std::string name;
     };
 
-    std::weak_ptr<ecs::GuiRenderable> CreateGuiWindow(const ecs::Gui &gui, const ecs::Scripts *scripts);
+    GuiContext::Ref CreateGuiWindow(const ecs::Gui &gui, const ecs::Scripts *scripts);
 
     std::span<GuiFontDef> GetGuiFontList();
 } // namespace sp

--- a/src/graphics/graphics/gui/OverlayGuiManager.cc
+++ b/src/graphics/graphics/gui/OverlayGuiManager.cc
@@ -61,11 +61,13 @@ namespace sp {
 
             if (renderable.PreDefine(ent)) {
                 ImVec2 windowSize(renderable.preferredSize.x, renderable.preferredSize.y);
-                windowSize.x = std::min(windowSize.x, std::min(viewportSize.x, imguiViewport->WorkSize.x * 0.4f));
-                windowSize.y = std::min(windowSize.y, std::min(viewportSize.y, imguiViewport->WorkSize.y * 0.4f));
-                if (windowSize.x <= 0) windowSize.x = viewportSize.x;
-                if (windowSize.y <= 0) windowSize.y = viewportSize.y;
-                ImGui::SetNextWindowSize(windowSize);
+                if (renderable.anchor != ecs::GuiLayoutAnchor::Floating) {
+                    windowSize.x = std::min(windowSize.x, std::min(viewportSize.x, imguiViewport->WorkSize.x * 0.4f));
+                    windowSize.y = std::min(windowSize.y, std::min(viewportSize.y, imguiViewport->WorkSize.y * 0.4f));
+                    if (windowSize.x <= 0) windowSize.x = viewportSize.x;
+                    if (windowSize.y <= 0) windowSize.y = viewportSize.y;
+                    ImGui::SetNextWindowSize(windowSize);
+                }
 
                 switch (renderable.anchor) {
                 case ecs::GuiLayoutAnchor::Fullscreen:

--- a/src/graphics/graphics/vulkan/core/DeviceContext.cc
+++ b/src/graphics/graphics/vulkan/core/DeviceContext.cc
@@ -626,7 +626,10 @@ namespace sp::vulkan {
 
     void DeviceContext::SetOverlayGui(OverlayGuiManager *overlayGui) {
         auto *perfTimer = GetPerfTimer();
-        if (perfTimer) overlayGui->Attach(make_shared<vulkan::ProfilerGui>(*perfTimer));
+        if (perfTimer) {
+            if (!profilerGui) profilerGui = make_shared<ProfilerGui>(*perfTimer);
+            overlayGui->Attach(profilerGui);
+        }
 
         if (vkRenderer) vkRenderer->SetOverlayGui(overlayGui);
     }

--- a/src/graphics/graphics/vulkan/core/DeviceContext.hh
+++ b/src/graphics/graphics/vulkan/core/DeviceContext.hh
@@ -20,6 +20,7 @@
 
 #include <atomic>
 #include <future>
+#include <memory>
 #include <robin_hood.h>
 #include <variant>
 
@@ -44,9 +45,10 @@ namespace sp::vulkan {
     class PerfTimer;
     class Pipeline;
     class PipelineManager;
-    struct PipelineCompileInput;
-    class Shader;
+    class ProfilerGui;
     class Renderer;
+    class Shader;
+    struct PipelineCompileInput;
 
     namespace render_graph {
         class Resources;
@@ -272,6 +274,7 @@ namespace sp::vulkan {
         DeferredFunc surfaceDestroy;
 
         unique_ptr<PerfTimer> perfTimer;
+        shared_ptr<ProfilerGui> profilerGui;
 
 #ifdef TRACY_ENABLE_GRAPHICS
         struct {


### PR DESCRIPTION
In this PR:
- Store the profiler GUI instance on the DeviceContext
- Fix the OverlayGuiManager for Floating windows
- Adjust the profiler GUI to make the window resizable