### PR TITLE
New Tonemapping settings

### DIFF
--- a/shaders/lib/shadow_sample.glsl
+++ b/shaders/lib/shadow_sample.glsl
@@ -67,24 +67,16 @@ float DirectOcclusion(ShadowInfo info, vec3 surfaceNormal, mat2 rotation0) {
 
     float values[SHADOW_MAP_SAMPLE_COUNT];
     float avgDepth = 0;
-    // float theta = M_PI / 2.0; // 45 degree start
-    // float r = 1.0;
-    // for (int i = 0; i < SHADOW_MAP_SAMPLE_COUNT; i++) {
-    //     vec2 spiralXY = vec2(sin(theta), cos(theta)) * sqrt(r);
-    //     vec2 modifiedCoord = shadowMapCoord + rotation0 * spiralXY * shadowSampleOffset * sampleScale;
-    //     values[i] = texture(TEXTURE_SAMPLER(modifiedCoord * info.mapOffset.zw + info.mapOffset.xy)).r;
-    //     avgDepth += values[i] * (1.0 - r);
-    //     theta += 2.0 * M_PI / M_GOLDEN_RATIO;
-    //     r -= 1.0 / SHADOW_MAP_SAMPLE_COUNT;
-    // }
-    // Quasirandom sequence inspired by
-    // https://extremelearning.com.au/unreasonable-effectiveness-of-quasirandom-sequences/
+    float theta = M_PI / 2.0; // 45 degree start
+    float r = 1.0;
+    vec3 texCoord = ViewPosToScreenPos(info.shadowMapPos, info.projMat);
     for (int i = 0; i < SHADOW_MAP_SAMPLE_COUNT; i++) {
-        vec2 qrandXY = vec2(fract((i + 1) / M_PLASTIC_RATIO_2D) * 2.0 - 1.0,
-            fract((i + 1) / (M_PLASTIC_RATIO_2D * M_PLASTIC_RATIO_2D)) * 2.0 - 1.0);
-        vec2 modifiedCoord = shadowMapCoord + rotation0 * qrandXY * shadowSampleOffset * sampleScale;
+        vec2 spiralXY = vec2(sin(theta), cos(theta)) * sqrt(r) * 1.41;
+        vec2 modifiedCoord = shadowMapCoord + rotation0 * spiralXY * shadowSampleOffset * sampleScale;
         values[i] = texture(TEXTURE_SAMPLER(modifiedCoord * info.mapOffset.zw + info.mapOffset.xy)).r;
-        avgDepth += values[i] * (1.0 - length(qrandXY) / sqrt(2));
+        avgDepth += values[i] * (1.0 - r);
+        theta += 2.0 * M_PI / M_GOLDEN_RATIO;
+        r -= 1.0 / (SHADOW_MAP_SAMPLE_COUNT - 0.5);
     }
     avgDepth /= (SHADOW_MAP_SAMPLE_COUNT + 1) * 0.5;
 

--- a/shaders/lib/shadow_sample.glsl
+++ b/shaders/lib/shadow_sample.glsl
@@ -66,16 +66,25 @@ float DirectOcclusion(ShadowInfo info, vec3 surfaceNormal, mat2 rotation0) {
     sampleScale *= fragmentDepth * 0.75 + 0.25;
 
     float values[SHADOW_MAP_SAMPLE_COUNT];
-    float theta = M_PI / 2.0; // 45 degree start
-    float r = 1.0;
     float avgDepth = 0;
+    // float theta = M_PI / 2.0; // 45 degree start
+    // float r = 1.0;
+    // for (int i = 0; i < SHADOW_MAP_SAMPLE_COUNT; i++) {
+    //     vec2 spiralXY = vec2(sin(theta), cos(theta)) * sqrt(r);
+    //     vec2 modifiedCoord = shadowMapCoord + rotation0 * spiralXY * shadowSampleOffset * sampleScale;
+    //     values[i] = texture(TEXTURE_SAMPLER(modifiedCoord * info.mapOffset.zw + info.mapOffset.xy)).r;
+    //     avgDepth += values[i] * (1.0 - r);
+    //     theta += 2.0 * M_PI / M_GOLDEN_RATIO;
+    //     r -= 1.0 / SHADOW_MAP_SAMPLE_COUNT;
+    // }
+    // Quasirandom sequence inspired by
+    // https://extremelearning.com.au/unreasonable-effectiveness-of-quasirandom-sequences/
     for (int i = 0; i < SHADOW_MAP_SAMPLE_COUNT; i++) {
-        vec2 spiralXY = vec2(sin(theta), cos(theta)) * sqrt(r);
-        vec2 modifiedCoord = shadowMapCoord + rotation0 * spiralXY * shadowSampleOffset * sampleScale;
+        vec2 qrandXY = vec2(fract((i + 1) / M_PLASTIC_RATIO_2D) * 2.0 - 1.0,
+            fract((i + 1) / (M_PLASTIC_RATIO_2D * M_PLASTIC_RATIO_2D)) * 2.0 - 1.0);
+        vec2 modifiedCoord = shadowMapCoord + rotation0 * qrandXY * shadowSampleOffset * sampleScale;
         values[i] = texture(TEXTURE_SAMPLER(modifiedCoord * info.mapOffset.zw + info.mapOffset.xy)).r;
-        avgDepth += values[i] * (1.0 - r);
-        theta += 2.0 * M_PI / M_GOLDEN_RATIO;
-        r -= 1.0 / SHADOW_MAP_SAMPLE_COUNT;
+        avgDepth += values[i] * (1.0 - length(qrandXY) / sqrt(2));
     }
     avgDepth /= (SHADOW_MAP_SAMPLE_COUNT + 1) * 0.5;
 

--- a/shaders/lib/util.glsl
+++ b/shaders/lib/util.glsl
@@ -12,6 +12,7 @@
 
 #define M_PI 3.1415926535897932384626433832795
 #define M_GOLDEN_RATIO 1.618033988749
+#define M_PLASTIC_RATIO_2D 1.32471795724474602596
 
 #define saturate(x) clamp(x, 0.0, 1.0)
 // hash(x) based on sin() is not identical across Nvidia/AMD

--- a/shaders/vulkan/tonemap.frag
+++ b/shaders/vulkan/tonemap.frag
@@ -40,7 +40,9 @@ void main() {
 #endif
 
     vec3 hsv = RGBtoHSV(toneMapped);
-    hsv.y = clamp(hsv.y, 0, 1) * clamp(mix(DARK_SATURATION, BRIGHT_SATURATION, sqrt(hsv.z)), 0, 1);
+    float brightness = clamp(hsv.z, 0, 1);
+    float darkMix = (2 - brightness) * brightness;
+    hsv.y = clamp(hsv.y, 0, 1) * clamp(mix(DARK_SATURATION, BRIGHT_SATURATION, darkMix), 0, 1);
     outFragColor = vec4(HSVtoRGB(hsv), luminosity.a);
 
 #ifdef DEBUG_OVEREXPOSED

--- a/shaders/vulkan/tonemap.frag
+++ b/shaders/vulkan/tonemap.frag
@@ -27,7 +27,7 @@ layout(constant_id = 2) const float WHITE_POINT_B = 8.0;
 layout(constant_id = 3) const float CURVE_SCALE = 2.9;
 layout(constant_id = 4) const float DARK_SATURATION = 0.7;
 layout(constant_id = 5) const float BRIGHT_SATURATION = 1.0;
-const float ditherAmount = 0.5 / 255.0;
+const float ditherAmount = 1.0 / 255.0;
 
 void main() {
     vec4 luminosity = texture(luminanceTex, vec3(inTexCoord, gl_ViewID_OVR)); // pre-exposed
@@ -36,8 +36,7 @@ void main() {
                       HableSDRTonemap(vec3(WHITE_POINT_R, WHITE_POINT_G, WHITE_POINT_B));
 
 #ifdef ENABLE_DITHER
-    vec4 rng = randState(inTexCoord.xyx);
-    toneMapped += (rand2(rng) - 0.5) * ditherAmount;
+    toneMapped += (InterleavedGradientNoise(gl_FragCoord.xy) - 0.5) * ditherAmount;
 #endif
 
     vec3 hsv = RGBtoHSV(toneMapped);

--- a/shaders/vulkan/tonemap.frag
+++ b/shaders/vulkan/tonemap.frag
@@ -8,7 +8,7 @@
 #version 430
 
 // #define DEBUG_OVEREXPOSED
-// #define ENABLE_DITHER
+#define ENABLE_DITHER
 
 #extension GL_OVR_multiview2 : enable
 layout(num_views = 2) in;
@@ -21,22 +21,19 @@ layout(binding = 0) uniform sampler2DArray luminanceTex;
 layout(location = 0) in vec2 inTexCoord;
 layout(location = 0) out vec4 outFragColor;
 
-const float whitePoint = 8.0;
-const float curveScale = 2.9;
+layout(constant_id = 0) const float WHITE_POINT_R = 8.0;
+layout(constant_id = 1) const float WHITE_POINT_G = 8.0;
+layout(constant_id = 2) const float WHITE_POINT_B = 8.0;
+layout(constant_id = 3) const float CURVE_SCALE = 2.9;
+layout(constant_id = 4) const float DARK_SATURATION = 0.7;
+layout(constant_id = 5) const float BRIGHT_SATURATION = 1.0;
 const float ditherAmount = 0.5 / 255.0;
-const vec2 saturation = vec2(0, 1);
 
 void main() {
     vec4 luminosity = texture(luminanceTex, vec3(inTexCoord, gl_ViewID_OVR)); // pre-exposed
 
-    vec3 toneMapped = HableSDRTonemap(max(vec3(0), luminosity.rgb) * curveScale) / HableSDRTonemap(vec3(whitePoint));
-
-#ifdef DEBUG_OVEREXPOSED
-    if (toneMapped.r > 1 || toneMapped.g > 1 || toneMapped.b > 1) {
-        // Highlight overexposed/blown out areas.
-        toneMapped = vec3(1, 0, 0);
-    }
-#endif
+    vec3 toneMapped = HableSDRTonemap(max(vec3(0), luminosity.rgb) * CURVE_SCALE) /
+                      HableSDRTonemap(vec3(WHITE_POINT_R, WHITE_POINT_G, WHITE_POINT_B));
 
 #ifdef ENABLE_DITHER
     vec4 rng = randState(inTexCoord.xyx);
@@ -44,6 +41,13 @@ void main() {
 #endif
 
     vec3 hsv = RGBtoHSV(toneMapped);
-    hsv.y = mix(saturation.x, saturation.y, hsv.y);
+    hsv.y = clamp(hsv.y, 0, 1) * clamp(mix(DARK_SATURATION, BRIGHT_SATURATION, sqrt(hsv.z)), 0, 1);
     outFragColor = vec4(HSVtoRGB(hsv), luminosity.a);
+
+#ifdef DEBUG_OVEREXPOSED
+    if (toneMapped.r > 1 || toneMapped.g > 1 || toneMapped.b > 1) {
+        // Highlight overexposed/blown out areas.
+        outFragColor = vec4(1, 0, 0, 1);
+    }
+#endif
 }

--- a/shaders/vulkan/tonemap.frag
+++ b/shaders/vulkan/tonemap.frag
@@ -26,7 +26,7 @@ layout(constant_id = 1) const float WHITE_POINT_G = 8.0;
 layout(constant_id = 2) const float WHITE_POINT_B = 8.0;
 layout(constant_id = 3) const float CURVE_SCALE = 2.9;
 layout(constant_id = 4) const float DARK_SATURATION = 0.7;
-layout(constant_id = 5) const float BRIGHT_SATURATION = 1.0;
+layout(constant_id = 5) const float BRIGHT_SATURATION = 1.2;
 const float ditherAmount = 1.0 / 255.0;
 
 void main() {

--- a/src/graphics/graphics/vulkan/core/DeviceContext.cc
+++ b/src/graphics/graphics/vulkan/core/DeviceContext.cc
@@ -4,6 +4,7 @@
  * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
  * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
+#define VULKAN_HPP_USE_REFLECT
 
 #include "DeviceContext.hh"
 
@@ -307,10 +308,6 @@ namespace sp::vulkan {
                 }
             }
 
-            // currently we have code that assumes the transfer queue family is different from the other queues
-            Assert(queueFamilyIndex[QUEUE_TYPE_TRANSFER] != queueFamilyIndex[QUEUE_TYPE_GRAPHICS],
-                "transfer queue family overlaps graphics queue");
-
             std::vector<vk::DeviceQueueCreateInfo> queueInfos;
             for (uint32_t i = 0; i < queueFamilies.size(); i++) {
                 if (queuesUsedCount[i] == 0) continue;
@@ -359,71 +356,51 @@ namespace sp::vulkan {
                 }
             }
 
-            vk::PhysicalDeviceVulkan12Features availableVulkan12Features;
-            vk::PhysicalDeviceVulkan11Features availableVulkan11Features;
+            vk::PhysicalDeviceVulkan12Features availableVulkan12Features = {};
+            vk::PhysicalDeviceVulkan11Features availableVulkan11Features = {};
             availableVulkan11Features.pNext = &availableVulkan12Features;
-            vk::PhysicalDeviceFeatures2 deviceFeatures2;
-            deviceFeatures2.pNext = &availableVulkan11Features;
+            vk::PhysicalDeviceFeatures2 availableDeviceFeatures2 = {};
+            availableDeviceFeatures2.pNext = &availableVulkan11Features;
+            auto &availableVulkan10Features = availableDeviceFeatures2.features;
+            selectedDevice.getFeatures2KHR(&availableDeviceFeatures2);
 
-            selectedDevice.getFeatures2KHR(&deviceFeatures2);
-
-            const auto &availableDeviceFeatures = deviceFeatures2.features;
-            Assert(availableDeviceFeatures.fillModeNonSolid, "device must support fillModeNonSolid");
-            Assert(availableDeviceFeatures.samplerAnisotropy, "device must support samplerAnisotropy");
-            Assert(availableDeviceFeatures.multiDrawIndirect, "device must support multiDrawIndirect");
-            Assert(availableDeviceFeatures.multiViewport, "device must support multiViewport");
-            Assert(availableDeviceFeatures.drawIndirectFirstInstance, "device must support drawIndirectFirstInstance");
-            Assert(availableDeviceFeatures.shaderInt16, "device must support shaderInt16");
-            Assert(availableDeviceFeatures.fragmentStoresAndAtomics, "device must support fragmentStoresAndAtomics");
-            Assert(availableDeviceFeatures.wideLines, "device must support wideLines");
-            Assert(availableVulkan11Features.multiview, "device must support multiview");
-            Assert(availableVulkan11Features.shaderDrawParameters, "device must support shaderDrawParameters");
-            Assert(availableVulkan11Features.storageBuffer16BitAccess, "device must support storageBuffer16BitAccess");
-            Assert(availableVulkan11Features.uniformAndStorageBuffer16BitAccess,
-                "device must support uniformAndStorageBuffer16BitAccess");
-            Assert(availableVulkan12Features.shaderOutputViewportIndex,
-                "device must support shaderOutputViewportIndex");
-            Assert(availableVulkan12Features.shaderOutputLayer, "device must support shaderOutputLayer");
-            Assert(availableVulkan12Features.drawIndirectCount, "device must support drawIndirectCount");
-            Assert(availableVulkan12Features.runtimeDescriptorArray, "device must support runtimeDescriptorArray");
-            Assert(availableVulkan12Features.descriptorBindingPartiallyBound,
-                "device must support descriptorBindingPartiallyBound");
-            Assert(availableVulkan12Features.descriptorBindingVariableDescriptorCount,
-                "device must support descriptorBindingVariableDescriptorCount");
-            Assert(availableVulkan12Features.shaderSampledImageArrayNonUniformIndexing,
-                "device must support shaderSampledImageArrayNonUniformIndexing");
-            Assert(availableVulkan12Features.descriptorBindingUpdateUnusedWhilePending,
-                "device must support descriptorBindingUpdateUnusedWhilePending");
-
-            vk::PhysicalDeviceVulkan12Features enabledVulkan12Features;
-            enabledVulkan12Features.shaderOutputViewportIndex = true;
-            enabledVulkan12Features.shaderOutputLayer = true;
-            enabledVulkan12Features.drawIndirectCount = true;
-            enabledVulkan12Features.runtimeDescriptorArray = true;
-            enabledVulkan12Features.descriptorBindingPartiallyBound = true;
-            enabledVulkan12Features.descriptorBindingVariableDescriptorCount = true;
-            enabledVulkan12Features.shaderSampledImageArrayNonUniformIndexing = true;
-            enabledVulkan12Features.descriptorBindingUpdateUnusedWhilePending = true;
-
-            vk::PhysicalDeviceVulkan11Features enabledVulkan11Features;
-            enabledVulkan11Features.storageBuffer16BitAccess = true;
-            enabledVulkan11Features.uniformAndStorageBuffer16BitAccess = true;
-            enabledVulkan11Features.multiview = true;
-            enabledVulkan11Features.shaderDrawParameters = true;
+            vk::PhysicalDeviceVulkan12Features enabledVulkan12Features = {};
+            vk::PhysicalDeviceVulkan11Features enabledVulkan11Features = {};
             enabledVulkan11Features.pNext = &enabledVulkan12Features;
-
-            vk::PhysicalDeviceFeatures2 enabledDeviceFeatures2;
+            vk::PhysicalDeviceFeatures2 enabledDeviceFeatures2 = {};
             enabledDeviceFeatures2.pNext = &enabledVulkan11Features;
-            auto &enabledDeviceFeatures = enabledDeviceFeatures2.features;
-            enabledDeviceFeatures.dualSrcBlend = true;
-            enabledDeviceFeatures.fillModeNonSolid = true;
-            enabledDeviceFeatures.samplerAnisotropy = true;
-            enabledDeviceFeatures.multiDrawIndirect = true;
-            enabledDeviceFeatures.drawIndirectFirstInstance = true;
-            enabledDeviceFeatures.multiViewport = true;
-            enabledDeviceFeatures.shaderInt16 = true;
-            enabledDeviceFeatures.fragmentStoresAndAtomics = true;
-            enabledDeviceFeatures.wideLines = true;
+            auto &enabledVulkan10Features = enabledDeviceFeatures2.features;
+
+#define REQUIRE_DEVICE_FEATURE(MAJOR_VERSION, MINOR_VERSION, NAME)                                                     \
+    if (availableVulkan##MAJOR_VERSION##MINOR_VERSION##Features.NAME) {                                                \
+        enabledVulkan##MAJOR_VERSION##MINOR_VERSION##Features.NAME = true;                                             \
+    } else {                                                                                                           \
+        Errorf("Graphics Device is missing required Vulkan %s.%s feature: %s", #MAJOR_VERSION, #MINOR_VERSION, #NAME); \
+    }
+
+            REQUIRE_DEVICE_FEATURE(1, 2, shaderOutputViewportIndex);
+            REQUIRE_DEVICE_FEATURE(1, 2, shaderOutputLayer);
+            REQUIRE_DEVICE_FEATURE(1, 2, drawIndirectCount);
+            REQUIRE_DEVICE_FEATURE(1, 2, runtimeDescriptorArray);
+            REQUIRE_DEVICE_FEATURE(1, 2, descriptorBindingPartiallyBound);
+            REQUIRE_DEVICE_FEATURE(1, 2, descriptorBindingVariableDescriptorCount);
+            REQUIRE_DEVICE_FEATURE(1, 2, shaderSampledImageArrayNonUniformIndexing);
+            REQUIRE_DEVICE_FEATURE(1, 2, descriptorBindingUpdateUnusedWhilePending);
+
+            REQUIRE_DEVICE_FEATURE(1, 1, storageBuffer16BitAccess);
+            REQUIRE_DEVICE_FEATURE(1, 1, uniformAndStorageBuffer16BitAccess);
+            REQUIRE_DEVICE_FEATURE(1, 1, multiview);
+            REQUIRE_DEVICE_FEATURE(1, 1, shaderDrawParameters);
+
+            REQUIRE_DEVICE_FEATURE(1, 0, dualSrcBlend);
+            REQUIRE_DEVICE_FEATURE(1, 0, fillModeNonSolid);
+            REQUIRE_DEVICE_FEATURE(1, 0, samplerAnisotropy);
+            REQUIRE_DEVICE_FEATURE(1, 0, multiDrawIndirect);
+            REQUIRE_DEVICE_FEATURE(1, 0, drawIndirectFirstInstance);
+            REQUIRE_DEVICE_FEATURE(1, 0, multiViewport);
+            REQUIRE_DEVICE_FEATURE(1, 0, shaderInt16);
+            REQUIRE_DEVICE_FEATURE(1, 0, fragmentStoresAndAtomics);
+            REQUIRE_DEVICE_FEATURE(1, 0, wideLines);
 
             vk::DeviceCreateInfo deviceInfo;
             deviceInfo.queueCreateInfoCount = queueInfos.size();

--- a/src/graphics/graphics/vulkan/render_passes/Mipmap.cc
+++ b/src/graphics/graphics/vulkan/render_passes/Mipmap.cc
@@ -17,46 +17,29 @@ namespace sp::vulkan::renderer {
         if (id == InvalidResource) id = graph.LastOutputID();
         graph.AddPass("Mipmap")
             .Build([&](rg::PassBuilder &builder) {
-                builder.Read(id, Access::TransferRead);
                 builder.Write(id, Access::TransferWrite);
+                builder.Read(id, Access::TransferRead);
             })
             .Execute([id](rg::Resources &resources, CommandContext &cmd) {
                 const auto &image = resources.GetImageView(id)->Image();
 
-                AccessInfo last = GetAccessInfo(image->LastAccess());
-                if (last.stageMask == vk::PipelineStageFlags(0)) last.stageMask = vk::PipelineStageFlagBits::eTopOfPipe;
-
                 ImageBarrierInfo transferMips = {};
                 transferMips.trackImageLayout = false;
-                transferMips.baseMipLevel = 0;
+                transferMips.baseMipLevel = 1;
                 transferMips.mipLevelCount = 1;
 
                 cmd.ImageBarrier(image,
-                    image->LastLayout(),
-                    vk::ImageLayout::eTransferSrcOptimal,
-                    last.stageMask,
-                    last.accessMask,
-                    vk::PipelineStageFlagBits::eTransfer,
-                    vk::AccessFlagBits::eTransferRead,
-                    transferMips);
-
-                transferMips.baseMipLevel = 1;
-                transferMips.mipLevelCount = image->MipLevels() - 1;
-
-                cmd.ImageBarrier(image,
-                    image->LastLayout(),
+                    vk::ImageLayout::eUndefined,
                     vk::ImageLayout::eTransferDstOptimal,
-                    last.stageMask,
-                    last.accessMask,
+                    vk::PipelineStageFlagBits::eTransfer,
+                    {},
                     vk::PipelineStageFlagBits::eTransfer,
                     vk::AccessFlagBits::eTransferWrite,
                     transferMips);
 
-                auto baseMipExtent = image->Extent();
-
-                vk::Offset3D currentExtent = {(int32_t)baseMipExtent.width,
-                    (int32_t)baseMipExtent.height,
-                    (int32_t)baseMipExtent.depth};
+                vk::Offset3D currentExtent = {(int32_t)image->Extent().width,
+                    (int32_t)image->Extent().height,
+                    (int32_t)image->Extent().depth};
 
                 for (uint32_t i = 1; i < image->MipLevels(); i++) {
                     auto prevMipExtent = currentExtent;
@@ -78,21 +61,20 @@ namespace sp::vulkan::renderer {
                         vk::ImageLayout::eTransferDstOptimal,
                         {blit},
                         vk::Filter::eLinear);
+
+                    transferMips.baseMipLevel = i;
+                    cmd.ImageBarrier(image,
+                        vk::ImageLayout::eTransferDstOptimal,
+                        vk::ImageLayout::eTransferSrcOptimal,
+                        vk::PipelineStageFlagBits::eTransfer,
+                        vk::AccessFlagBits::eTransferWrite,
+                        vk::PipelineStageFlagBits::eTransfer,
+                        vk::AccessFlagBits::eTransferRead,
+                        transferMips);
                 }
 
-                transferMips.baseMipLevel = 0;
-                transferMips.mipLevelCount = 1;
-                cmd.ImageBarrier(image,
-                    vk::ImageLayout::eTransferSrcOptimal,
-                    vk::ImageLayout::eTransferDstOptimal,
-                    vk::PipelineStageFlagBits::eTransfer,
-                    vk::AccessFlagBits::eTransferRead,
-                    vk::PipelineStageFlagBits::eTransfer,
-                    vk::AccessFlagBits::eTransferWrite,
-                    transferMips);
-
-                // Each mip has now been transitioned to TransferDst.
-                image->SetLayout(vk::ImageLayout::eUndefined, vk::ImageLayout::eTransferDstOptimal);
+                // Each mip has now been transitioned to TransferSrc.
+                image->SetLayout(vk::ImageLayout::eUndefined, vk::ImageLayout::eTransferSrcOptimal);
             });
     }
 } // namespace sp::vulkan::renderer

--- a/src/graphics/graphics/vulkan/render_passes/Tonemap.cc
+++ b/src/graphics/graphics/vulkan/render_passes/Tonemap.cc
@@ -20,7 +20,7 @@ namespace sp::vulkan::renderer {
         0.7,
         "The HSV saturation scale for dark parts of the scene.");
     static CVar<float> CVarBrightSaturation("r.TonemapBrightSaturation",
-        1.1,
+        1.2,
         "The HSV saturation scale for bright parts of the scene.");
 
     void AddTonemap(RenderGraph &graph) {

--- a/src/graphics/graphics/vulkan/render_passes/Tonemap.cc
+++ b/src/graphics/graphics/vulkan/render_passes/Tonemap.cc
@@ -7,10 +7,27 @@
 
 #include "Tonemap.hh"
 
+#include "console/CVar.hh"
 #include "graphics/vulkan/core/CommandContext.hh"
+#include "graphics/vulkan/core/Shader.hh"
 
 namespace sp::vulkan::renderer {
+    static CVar<glm::vec3> CVarWhitePoint("r.TonemapWhitePoint",
+        glm::vec3(8),
+        "The target whitepoint for HDR to SDR tonemapping.");
+    static CVar<float> CVarGammaCurve("r.TonemapGammaCurve", 2.9, "The gamma curve scale for your display.");
+    static CVar<float> CVarDarkSaturation("r.TonemapDarkSaturation",
+        0.7,
+        "The HSV saturation scale for dark parts of the scene.");
+    static CVar<float> CVarBrightSaturation("r.TonemapBrightSaturation",
+        1.1,
+        "The HSV saturation scale for bright parts of the scene.");
+
     void AddTonemap(RenderGraph &graph) {
+        glm::vec3 whitePoint = CVarWhitePoint.Get();
+        float gammaCurve = CVarGammaCurve.Get();
+        float darkSaturation = CVarDarkSaturation.Get();
+        float brightSaturation = CVarBrightSaturation.Get();
         graph.AddPass("Tonemap")
             .Build([&](rg::PassBuilder &builder) {
                 auto luminanceID = builder.LastOutputID();
@@ -20,9 +37,18 @@ namespace sp::vulkan::renderer {
                 desc.format = vk::Format::eR8G8B8A8Srgb;
                 builder.OutputColorAttachment(0, "TonemappedLuminance", desc, {LoadOp::DontCare, StoreOp::Store});
             })
-            .Execute([](rg::Resources &resources, CommandContext &cmd) {
+            .Execute([whitePoint, gammaCurve, darkSaturation, brightSaturation](rg::Resources &resources,
+                         CommandContext &cmd) {
                 cmd.SetShaders("screen_cover.vert", "tonemap.frag");
                 cmd.SetImageView("luminanceTex", resources.LastOutputID());
+                cmd.SetShaderConstant(ShaderStage::Fragment, "WHITE_POINT_R", whitePoint.r);
+                cmd.SetShaderConstant(ShaderStage::Fragment, "WHITE_POINT_G", whitePoint.g);
+                cmd.SetShaderConstant(ShaderStage::Fragment, "WHITE_POINT_B", whitePoint.b);
+
+                cmd.SetShaderConstant(ShaderStage::Fragment, "CURVE_SCALE", gammaCurve);
+                cmd.SetShaderConstant(ShaderStage::Fragment, "DARK_SATURATION", darkSaturation);
+                cmd.SetShaderConstant(ShaderStage::Fragment, "BRIGHT_SATURATION", brightSaturation);
+
                 cmd.Draw(3);
             });
     }

--- a/src/graphics/gui/MenuGuiManager.cc
+++ b/src/graphics/gui/MenuGuiManager.cc
@@ -16,6 +16,7 @@
 #include "game/Game.hh"
 #include "game/SceneManager.hh"
 #include "glm/fwd.hpp"
+#include "glm/gtx/component_wise.hpp"
 #include "graphics/GenericCompositor.hh"
 #include "graphics/core/GraphicsContext.hh"
 #include "graphics/core/GraphicsManager.hh"
@@ -332,6 +333,8 @@ namespace sp {
                 ImGui::TextUnformatted("Full Screen");
                 ImGui::TextUnformatted("Show FPS");
                 ImGui::TextUnformatted("Field of View");
+                ImGui::TextUnformatted("Tonemap White Point");
+                ImGui::TextUnformatted("Display Gamma");
                 ImGui::TextUnformatted("UI Scaling");
                 ImGui::TextUnformatted("Mirror VR View");
                 ImGui::TextUnformatted("Voxel Lighting Mode");
@@ -403,6 +406,27 @@ namespace sp {
                     ImGui::PushItemWidth(300.0f);
                     if (ImGui::SliderFloat("##fovDegrees", &fovDegrees, 1.0f, 160.0f, "%.0f degrees")) {
                         fovCVar.Set(fovDegrees);
+                    }
+                }
+                {
+                    auto &whitePointCVar = GetConsoleManager().GetCVar<glm::vec3>("r.tonemapwhitepoint");
+                    float whitePoint = glm::compMax(whitePointCVar.Get());
+                    ImGui::PushItemWidth(300.0f);
+                    if (ImGui::SliderFloat("##whitePoint",
+                            &whitePoint,
+                            1.0f,
+                            16.0f,
+                            "%.1f",
+                            ImGuiSliderFlags_Logarithmic)) {
+                        whitePointCVar.Set(glm::vec3(whitePoint));
+                    }
+                }
+                {
+                    auto &gammaCurveCVar = GetConsoleManager().GetCVar<float>("r.tonemapgammacurve");
+                    float gammaCurve = gammaCurveCVar.Get();
+                    ImGui::PushItemWidth(300.0f);
+                    if (ImGui::SliderFloat("##gammaCurve", &gammaCurve, 1.0f, 16.0f, "%.1f")) {
+                        gammaCurveCVar.Set(gammaCurve);
                     }
                 }
                 {


### PR DESCRIPTION
- Enable dithering during HDR to SDR tonemapping
- Add gamma curve slider to options
- Add new console variables for tonemapping
- Support separate saturation values for light and dark scene areas
- Improve compatibility with integrated graphics
- Fix render output mipmapping race condition
- Slightly adjust shadow map sampling pattern